### PR TITLE
Set up test infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 
         <!-- Change Bukkit Version HERE! -->
         <bukkit.version>1.12-R0.1-SNAPSHOT</bukkit.version>
+        <powermock.version>1.7.3</powermock.version>
     </properties>
 
     <licenses>
@@ -112,11 +113,44 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>1.2</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.natpryce</groupId>
+            <artifactId>hamkrest</artifactId>
+            <version>1.4.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <!-- Note ljacqu 20171125: Powermock doesn't work with anything above 2.9 because of a removed class -->
+            <version>2.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <!-- testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory -->
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 
         <defaultGoal>clean install</defaultGoal>
         <resources>

--- a/src/test/kotlin/me.ebonjaeger.perworldinventory/GroupManagerTest.kt
+++ b/src/test/kotlin/me.ebonjaeger.perworldinventory/GroupManagerTest.kt
@@ -1,0 +1,29 @@
+package me.ebonjaeger.perworldinventory
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+/**
+ * Test for [GroupManager].
+ */
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(PerWorldInventory::class)
+class GroupManagerTest {
+
+    @InjectMocks
+    lateinit var groupManager: GroupManager
+
+    @Mock
+    lateinit var plugin: PerWorldInventory
+
+    @Test
+    fun shouldReturnAbsentValueForNonExistentGroup() {
+        assertThat(groupManager.getGroup("test"), absent())
+    }
+}

--- a/src/test/kotlin/me.ebonjaeger.perworldinventory/GroupTest.kt
+++ b/src/test/kotlin/me.ebonjaeger.perworldinventory/GroupTest.kt
@@ -1,0 +1,39 @@
+package me.ebonjaeger.perworldinventory
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.bukkit.GameMode
+import org.junit.Test
+
+/**
+ * Test for [Group].
+ */
+class GroupTest {
+
+    @Test
+    fun shouldCreateNewGroup() {
+        // given
+        val group = Group("test", mutableSetOf("world1", "world2"), GameMode.SURVIVAL)
+
+        // when / then
+        assertThat(group.containsWorld("world2"), equalTo(true))
+        assertThat(group.containsWorld("other"), equalTo(false))
+    }
+
+    @Test
+    fun shouldAddNewWorlds() {
+        // given
+        val group = Group("my_group", mutableSetOf("world1"), GameMode.ADVENTURE)
+
+        // when
+        group.addWorld("other")
+        group.addWorlds(setOf("one", "two"))
+
+        // then
+        val existingWorlds = setOf("world1", "other", "one", "two")
+        existingWorlds.forEach { world ->
+            assertThat("World $world should be included", group.containsWorld(world), equalTo(true))
+        }
+        assertThat(group.containsWorld("bogus"), equalTo(false))
+    }
+}


### PR DESCRIPTION
We're in for a rough ride... 

Kotlin classes are final by default so we need Powermock to be able to mock them. Notice `@PrepareForTest(PerWorldInventory::class)` on one of the test classes, which tells Powermock it needs to handle that class. Also, variables need to be declared as `lateinit` since we need Mockito to do its thing.

I tried setting up the test infrastructure with Spek initially, but after I couldn't get the tests to run in the IDE I gave up and went with JUnit. It shouldn't take a lot of work to make tests runnable in one's IDE.