### PR TITLE
Add tests for the ItemSerializer.

### DIFF
--- a/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemMetaImpl.kt
+++ b/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemMetaImpl.kt
@@ -29,9 +29,8 @@ class ItemMetaTestImpl : ItemMeta {
         this.providedMap = map
     }
 
-    override fun serialize(): MutableMap<String, Any> {
-        return HashMap(this.providedMap)
-    }
+    override fun serialize(): MutableMap<String, Any> =
+            HashMap(this.providedMap)
 
     override fun clone(): ItemMeta {
         val mapClone = HashMap(providedMap)

--- a/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemSerializerTest.kt
+++ b/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemSerializerTest.kt
@@ -99,7 +99,7 @@ class ItemSerializerTest {
                 fail("Map is empty!")
             } else {
                 for (entry in expectedItemMeta.providedMap.entries) {
-                    assertThat(givenItemMeta.providedMap.get(entry.key), equalTo(entry.value))
+                    assertThat(givenItemMeta.providedMap[entry.key], equalTo(entry.value))
                 }
             }
         } else {

--- a/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemSerializerTest.kt
+++ b/src/test/kotlin/me.ebonjaeger.perworldinventory/serialization/ItemSerializerTest.kt
@@ -1,0 +1,70 @@
+package me.ebonjaeger.perworldinventory.serialization
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.ItemFactory
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.powermock.api.mockito.PowerMockito.*
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+/**
+ * Tests for [ItemSerializer].
+ */
+@RunWith(PowerMockRunner::class)
+class ItemSerializerTest
+{
+
+    @Test
+    @PrepareForTest(Bukkit::class)
+    fun verifySerializedItem()
+    {
+        // given
+        mockStatic(Bukkit::class.java)
+        val itemFactory = mock(ItemFactory::class.java)
+        `when`(Bukkit.getItemFactory()).thenReturn(itemFactory)
+        `when`(itemFactory.getItemMeta(any())).thenReturn(mock(ItemMeta::class.java))
+
+        val item = ItemStack(Material.APPLE, 5)
+
+        // when
+        val json = ItemSerializer.serialize(item, 1)
+
+        // then
+        val result = ItemSerializer.deserialize(json, 2)
+        assertThat(result, equalTo(item))
+    }
+
+    @Test
+    @PrepareForTest(Bukkit::class)
+    fun verifySerializedItemWithMeta()
+    {
+        // given
+        mockStatic(Bukkit::class.java)
+        val itemFactory = mock(ItemFactory::class.java)
+        `when`(Bukkit.getItemFactory()).thenReturn(itemFactory)
+        `when`(itemFactory.getItemMeta(any())).thenReturn(mock(ItemMeta::class.java))
+
+        val item = ItemStack(Material.APPLE, 3)
+        val meta = Bukkit.getItemFactory().getItemMeta(Material.APPLE)
+        meta.displayName = "Testing Apple"
+        meta.addEnchant(Enchantment.DURABILITY, 1 ,false)
+        meta.lore.add("Very Strong Apple")
+        item.itemMeta = meta
+
+        // when
+        val json = ItemSerializer.serialize(item, 0)
+
+        // then
+        // deserialize item and test for match
+        val result = ItemSerializer.deserialize(json, 2)
+        assertThat(result, equalTo(item))
+    }
+}


### PR DESCRIPTION
The tests are currently broken due to an issue with trying to mock an item's ItemMeta. Both tests fail with the same message: `Caused by: java.lang.IllegalArgumentException: Specified class does not exist ('org.bukkit.inventory.meta.ItemMeta$MockitoMock$119817158')`.

The full stack trace is:

```
java.io.IOException: Failed to deserialize object

	at org.bukkit.util.io.BukkitObjectInputStream.newIOException(BukkitObjectInputStream.java:58)
	at org.bukkit.util.io.BukkitObjectInputStream.resolveObject(BukkitObjectInputStream.java:50)
	at java.io.ObjectInputStream.checkResolve(ObjectInputStream.java:1616)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.readArray(ObjectInputStream.java:1970)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1562)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2206)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2282)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2206)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2064)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1568)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:428)
	at me.ebonjaeger.perworldinventory.serialization.ItemSerializer.deserialize(ItemSerializer.kt:73)
	at me.ebonjaeger.perworldinventory.serialization.ItemSerializerTest.verifySerializedItemWithMeta(ItemSerializerTest.kt:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.internal.runners.TestMethod.invoke(TestMethod.java:68)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.runTestMethod(PowerMockJUnit44RunnerDelegateImpl.java:326)
	at org.junit.internal.runners.MethodRoadie$2.run(MethodRoadie.java:89)
	at org.junit.internal.runners.MethodRoadie.runBeforesThenTestThenAfters(MethodRoadie.java:97)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.executeTest(PowerMockJUnit44RunnerDelegateImpl.java:310)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.executeTestInSuper(PowerMockJUnit47RunnerDelegateImpl.java:131)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.access$100(PowerMockJUnit47RunnerDelegateImpl.java:59)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner$TestExecutorStatement.evaluate(PowerMockJUnit47RunnerDelegateImpl.java:147)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.evaluateStatement(PowerMockJUnit47RunnerDelegateImpl.java:107)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit47RunnerDelegateImpl$PowerMockJUnit47MethodRunner.executeTest(PowerMockJUnit47RunnerDelegateImpl.java:82)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$PowerMockJUnit44MethodRunner.runBeforesThenTestThenAfters(PowerMockJUnit44RunnerDelegateImpl.java:298)
	at org.junit.internal.runners.MethodRoadie.runTest(MethodRoadie.java:87)
	at org.junit.internal.runners.MethodRoadie.run(MethodRoadie.java:50)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.invokeTestMethod(PowerMockJUnit44RunnerDelegateImpl.java:218)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.runMethods(PowerMockJUnit44RunnerDelegateImpl.java:160)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl$1.run(PowerMockJUnit44RunnerDelegateImpl.java:134)
	at org.junit.internal.runners.ClassRoadie.runUnprotected(ClassRoadie.java:34)
	at org.junit.internal.runners.ClassRoadie.runProtected(ClassRoadie.java:44)
	at org.powermock.modules.junit4.internal.impl.PowerMockJUnit44RunnerDelegateImpl.run(PowerMockJUnit44RunnerDelegateImpl.java:136)
	at org.powermock.modules.junit4.common.internal.impl.JUnit4TestSuiteChunkerImpl.run(JUnit4TestSuiteChunkerImpl.java:121)
	at org.powermock.modules.junit4.common.internal.impl.AbstractCommonPowerMockRunner.run(AbstractCommonPowerMockRunner.java:57)
	at org.powermock.modules.junit4.PowerMockRunner.run(PowerMockRunner.java:59)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.IllegalArgumentException: Specified class does not exist ('org.bukkit.inventory.meta.ItemMeta$MockitoMock$119817158')
	at org.bukkit.configuration.serialization.ConfigurationSerialization.deserializeObject(ConfigurationSerialization.java:185)
	at org.bukkit.util.io.BukkitObjectInputStream.resolveObject(BukkitObjectInputStream.java:48)
	... 46 more
```

I hate doing this, but @ljacqu do you happen to have any insight on this?