### PR TITLE
tech: Use SingletonStore in favor of using injector directly

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/DataSourceProvider.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/DataSourceProvider.kt
@@ -1,11 +1,11 @@
 package me.ebonjaeger.perworldinventory.data
 
-import ch.jalu.injector.Injector
+import ch.jalu.injector.factory.SingletonStore
 import me.ebonjaeger.perworldinventory.ConsoleLogger
 import javax.inject.Inject
 import javax.inject.Provider
 
-class DataSourceProvider @Inject constructor (private val injector: Injector) : Provider<DataSource>
+class DataSourceProvider @Inject constructor (private val dataSourceStore: SingletonStore<DataSource>) : Provider<DataSource>
 {
 
     override fun get(): DataSource
@@ -23,6 +23,6 @@ class DataSourceProvider @Inject constructor (private val injector: Injector) : 
     private fun createDataSource(): DataSource
     {
         // Later on we will have logic here to differentiate between flatfile and MySQL.
-        return injector.getSingleton(FlatFile::class.java)
+        return dataSourceStore.getSingleton(FlatFile::class.java)
     }
 }


### PR DESCRIPTION
I saw with great interest that you've incorporated the injector—awesome! :)

This is just a small change, replacing injection of the injector with a `SingletonStore`. Introduced in 1.0, it allows you to get/create singletons of a certain type and subtypes without having to expose all functions of the injector.
In parallel there also exists an injectable `Factory<T>` type which allows to instantiate objects of type `T` or of any subtype in request scope (i.e. like `Injector#newInstance`).