### PR TITLE
Initialization architecture

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.stream.JsonReader
+import me.ebonjaeger.perworldinventory.initialization.PluginFolder
+import me.ebonjaeger.perworldinventory.service.BukkitService
 import org.bukkit.GameMode
 import java.io.File
 import java.io.FileReader
@@ -12,10 +14,11 @@ import java.io.FileWriter
 import javax.annotation.PostConstruct
 import javax.inject.Inject
 
-class GroupManager @Inject constructor(private val plugin: PerWorldInventory)
+class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
+                                       private val bukkitService: BukkitService)
 {
 
-    private val WORLDS_CONFIG_FILE = File(plugin.dataFolder, "worlds.json")
+    private val WORLDS_CONFIG_FILE = File(pluginFolder, "worlds.json")
 
     val groups = mutableMapOf<String, Group>()
 
@@ -79,13 +82,13 @@ class GroupManager @Inject constructor(private val plugin: PerWorldInventory)
     {
         groups.clear()
 
-        plugin.server.scheduler.runTaskAsynchronously(plugin, {
+        bukkitService.runTaskAsynchronously({
             JsonReader(FileReader(WORLDS_CONFIG_FILE)).use {
                 val parser = JsonParser()
                 val data = parser.parse(it).asJsonObject
                 val root = data["groups"].asJsonObject
 
-                plugin.server.scheduler.runTask(plugin, {
+                bukkitService.runTask({
                     val gson = Gson()
                     for (jsonGroup in root.entrySet())
                     {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -1,7 +1,5 @@
 package me.ebonjaeger.perworldinventory
 
-import ch.jalu.configme.migration.PlainMigrationService
-import ch.jalu.configme.resource.YamlFileResource
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -12,8 +10,10 @@ import me.ebonjaeger.perworldinventory.configuration.Settings
 import me.ebonjaeger.perworldinventory.data.DataSource
 import me.ebonjaeger.perworldinventory.data.DataSourceProvider
 import me.ebonjaeger.perworldinventory.data.ProfileManager
+import me.ebonjaeger.perworldinventory.initialization.DataDirectory
 import me.ebonjaeger.perworldinventory.initialization.Injector
 import me.ebonjaeger.perworldinventory.initialization.InjectorBuilder
+import me.ebonjaeger.perworldinventory.initialization.PluginFolder
 import me.ebonjaeger.perworldinventory.listener.player.InventoryCreativeListener
 import me.ebonjaeger.perworldinventory.listener.player.PlayerChangedWorldListener
 import me.ebonjaeger.perworldinventory.listener.player.PlayerQuitListener
@@ -58,7 +58,7 @@ class PerWorldInventory : JavaPlugin()
     val timeouts = hashMapOf<UUID, Int>()
     var updateTimeoutsTaskId = -1
 
-    val DATA_DIRECTORY = File(dataFolder, "data")
+    private val DATA_DIRECTORY = File(dataFolder, "data")
     val SLOT_TIMEOUT = 5
     val WORLDS_CONFIG_FILE = File(dataFolder, "worlds.json")
 
@@ -87,12 +87,10 @@ class PerWorldInventory : JavaPlugin()
         val injector = InjectorBuilder().addDefaultHandlers("me.ebonjaeger.perworldinventory").create()
         injector.register(PerWorldInventory::class, this)
         injector.register(Server::class, server)
+        injector.provide(PluginFolder::class, dataFolder)
+        injector.provide(DataDirectory::class, DATA_DIRECTORY)
         injector.registerProvider(DataSource::class, DataSourceProvider::class)
-        val settings = Settings(YamlFileResource(File(dataFolder, "config.yml")),
-                PlainMigrationService(),
-                PluginSettings::class.java,
-                MetricsSettings::class.java,
-                PlayerSettings::class.java)
+        val settings = Settings.create(File(dataFolder, "config.yml"))
         injector.register(Settings::class, settings)
         injectServices(injector)
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -25,13 +25,15 @@ import org.bukkit.Bukkit
 import org.bukkit.Server
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.configuration.file.YamlConfiguration
+import org.bukkit.plugin.PluginDescriptionFile
 import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.plugin.java.JavaPluginLoader
 import java.io.File
 import java.io.FileWriter
 import java.nio.file.Files
 import java.util.*
 
-class PerWorldInventory : JavaPlugin()
+class PerWorldInventory : JavaPlugin
 {
 
     /**
@@ -61,6 +63,12 @@ class PerWorldInventory : JavaPlugin()
     private val DATA_DIRECTORY = File(dataFolder, "data")
     val SLOT_TIMEOUT = 5
     val WORLDS_CONFIG_FILE = File(dataFolder, "worlds.json")
+
+    constructor(): super()
+
+    /* Constructor used for tests. */
+    internal constructor(loader: JavaPluginLoader, description: PluginDescriptionFile, dataFolder: File, file: File?)
+            : super(loader, description, dataFolder, file)
 
     override fun onEnable()
     {
@@ -135,7 +143,7 @@ class PerWorldInventory : JavaPlugin()
         server.scheduler.cancelTasks(this)
     }
 
-    private fun injectServices(injector: Injector)
+    internal fun injectServices(injector: Injector)
     {
         injector.getSingleton(GroupManager::class)
         injector.getSingleton(PlayerSerializer::class)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/Settings.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/Settings.kt
@@ -3,7 +3,9 @@ package me.ebonjaeger.perworldinventory.configuration
 import ch.jalu.configme.SettingsHolder
 import ch.jalu.configme.SettingsManager
 import ch.jalu.configme.migration.MigrationService
+import ch.jalu.configme.migration.PlainMigrationService
 import ch.jalu.configme.resource.YamlFileResource
+import java.io.File
 
 /**
  * Settings class for PWI settings.
@@ -12,11 +14,29 @@ import ch.jalu.configme.resource.YamlFileResource
  * @param migrater The configuration migrater to use to add new config options
  * @param settingsHolders Classes that hold the actual properties
  */
-class Settings(file: YamlFileResource,
-               migrater: MigrationService,
-               vararg settingsHolders: Class<out SettingsHolder>) :
+class Settings private constructor(file: YamlFileResource,
+                                   migrater: MigrationService,
+                                   vararg settingsHolders: Class<out SettingsHolder>) :
         SettingsManager(file, migrater, *settingsHolders)
 {
 
+    companion object {
 
+        /** All [SettingsHolder] classes of PerWorldInventory. */
+        private val PROPERTY_HOLDERS = arrayOf(
+            PluginSettings::class.java, MetricsSettings::class.java, PlayerSettings::class.java)
+
+        /**
+         * Creates a [Settings] instance, using the given file as config file.
+         *
+         * @param file the config file to load
+         * @return settings instance for the file
+         */
+        fun create(file: File): Settings {
+            val fileResource = YamlFileResource(file)
+            val migrater = PlainMigrationService()
+
+            return Settings(fileResource, migrater, *PROPERTY_HOLDERS)
+        }
+    }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.stream.JsonReader
 import me.ebonjaeger.perworldinventory.ConsoleLogger
-import me.ebonjaeger.perworldinventory.PerWorldInventory
+import me.ebonjaeger.perworldinventory.initialization.DataDirectory
 import me.ebonjaeger.perworldinventory.serialization.LocationSerializer
 import me.ebonjaeger.perworldinventory.serialization.PlayerSerializer
 import org.bukkit.GameMode
@@ -18,8 +18,8 @@ import java.io.IOException
 import java.nio.file.Files
 import javax.inject.Inject
 
-class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
-               private val serializer: PlayerSerializer) : DataSource
+class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: File,
+                                   private val serializer: PlayerSerializer) : DataSource
 {
 
     override fun savePlayer(key: ProfileKey, player: PlayerProfile)
@@ -52,7 +52,7 @@ class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
 
     override fun saveLogout(player: PlayerProfile)
     {
-        val dir = File(plugin.DATA_DIRECTORY, player.uuid.toString())
+        val dir = File(dataDirectory, player.uuid.toString())
         val file = File(dir, "last-logout.json")
 
         try
@@ -71,7 +71,7 @@ class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
 
     override fun saveLocation(player: Player, location: Location)
     {
-        val dir = File(plugin.DATA_DIRECTORY, player.uniqueId.toString())
+        val dir = File(dataDirectory, player.uniqueId.toString())
         val file = File(dir, "last-locations.json")
 
         try
@@ -132,7 +132,7 @@ class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
 
     override fun getLogout(player: Player): Location?
     {
-        val dir = File(plugin.DATA_DIRECTORY, player.uniqueId.toString())
+        val dir = File(dataDirectory, player.uniqueId.toString())
         val file = File(dir, "last-logout.json")
 
         // This player is likely logging in for the first time
@@ -151,7 +151,7 @@ class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
 
     override fun getLocation(player: Player, world: String): Location?
     {
-        val dir = File(plugin.DATA_DIRECTORY, player.uniqueId.toString())
+        val dir = File(dataDirectory, player.uniqueId.toString())
         val file = File(dir, "last-locations.json")
 
         // Clearly they haven't visited any other worlds yet
@@ -212,7 +212,7 @@ class FlatFile @Inject constructor(private val plugin: PerWorldInventory,
      */
     private fun getFile(key: ProfileKey): File
     {
-        val dir = File(plugin.DATA_DIRECTORY, key.uuid.toString())
+        val dir = File(dataDirectory, key.uuid.toString())
         return when(key.gameMode)
         {
             GameMode.ADVENTURE -> File(dir, key.group.name + "_adventure.json")

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/initialization/DataDirectory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/initialization/DataDirectory.kt
@@ -1,0 +1,9 @@
+package me.ebonjaeger.perworldinventory.initialization
+
+/**
+ * Annotation used to identify the data directory for injection. Not to confuse with
+ * [PluginFolder], which Bukkit refers to as "data folder."
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DataDirectory

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/initialization/PluginFolder.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/initialization/PluginFolder.kt
@@ -1,0 +1,8 @@
+package me.ebonjaeger.perworldinventory.initialization
+
+/**
+ * Annotation used to identify the plugin's data folder for injection.
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PluginFolder

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -1,0 +1,29 @@
+package me.ebonjaeger.perworldinventory.service
+
+import me.ebonjaeger.perworldinventory.PerWorldInventory
+import org.bukkit.scheduler.BukkitTask
+import javax.inject.Inject
+
+/**
+ * Service for functions around the server the plugin is running on (scheduling tasks, etc.).
+ *
+ * @param plugin the plugin instance
+ */
+class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
+{
+
+    private val scheduler = plugin.server.scheduler
+
+    fun isShuttingDown() =
+        plugin.isShuttingDown
+
+    fun getServerVersion() =
+        plugin.server.version
+
+    fun runTaskAsynchronously(task: () -> Unit) =
+        scheduler.runTaskAsynchronously(plugin, task)
+
+    fun runTask(task: () -> Unit): BukkitTask =
+        scheduler.runTask(plugin, task)
+
+}

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/GroupManagerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/GroupManagerTest.kt
@@ -4,27 +4,26 @@ import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import me.ebonjaeger.perworldinventory.TestHelper.mockGroup
+import me.ebonjaeger.perworldinventory.service.BukkitService
 import org.bukkit.GameMode
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
+import org.mockito.Mockito
 import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
+import java.io.File
 
 /**
  * Test for [GroupManager].
  */
 @RunWith(PowerMockRunner::class)
-@PrepareForTest(PerWorldInventory::class)
+@PrepareForTest(BukkitService::class)
 class GroupManagerTest {
 
-    @InjectMocks
-    lateinit var groupManager: GroupManager
+    private val bukkitService = Mockito.mock(BukkitService::class.java)
 
-    @Mock
-    lateinit var plugin: PerWorldInventory
+    private val groupManager = GroupManager(File(""), bukkitService)
 
     @Test
     fun shouldReturnAbsentValueForNonExistentGroup() {

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventoryInitializationTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventoryInitializationTest.kt
@@ -1,0 +1,121 @@
+package me.ebonjaeger.perworldinventory
+
+import ch.jalu.configme.properties.Property
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import me.ebonjaeger.perworldinventory.data.DataSource
+import me.ebonjaeger.perworldinventory.data.DataSourceProvider
+import me.ebonjaeger.perworldinventory.initialization.DataDirectory
+import me.ebonjaeger.perworldinventory.initialization.Injector
+import me.ebonjaeger.perworldinventory.initialization.InjectorBuilder
+import me.ebonjaeger.perworldinventory.initialization.PluginFolder
+import me.ebonjaeger.perworldinventory.listener.player.InventoryCreativeListener
+import me.ebonjaeger.perworldinventory.listener.player.PlayerQuitListener
+import me.ebonjaeger.perworldinventory.listener.player.PlayerTeleportListener
+import me.ebonjaeger.perworldinventory.service.BukkitService
+import org.bukkit.Bukkit
+import org.bukkit.Server
+import org.bukkit.event.Listener
+import org.bukkit.plugin.PluginDescriptionFile
+import org.bukkit.plugin.PluginLogger
+import org.bukkit.plugin.PluginManager
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.plugin.java.JavaPluginLoader
+import org.bukkit.scheduler.BukkitScheduler
+import org.hamcrest.core.IsNot.not
+import org.hamcrest.core.IsNull.nullValue
+import org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import java.io.File
+import java.util.logging.Logger
+import kotlin.reflect.KClass
+
+
+/**
+ * Test for the initialization of [PerWorldInventory].
+ */
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(PerWorldInventory::class, Settings::class)
+class PerWorldInventoryInitializationTest {
+
+    @Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Mock
+    private lateinit var server: Server
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var pluginManager: PluginManager
+
+    private lateinit var pluginFolder: File
+    private lateinit var plugin: PerWorldInventory
+
+    @Before
+    fun mockServer() {
+        pluginFolder = temporaryFolder.newFolder()
+
+        setField(Bukkit::class, null, "server", server)
+        given(server.logger).willReturn(mock(Logger::class.java))
+        given(server.scheduler).willReturn(mock(BukkitScheduler::class.java))
+        given(server.pluginManager).willReturn(pluginManager)
+        given(server.version).willReturn("1.9.4-RC1")
+
+        given(settings.getProperty(any(Property::class.java))).willAnswer(
+                { invocation -> (invocation.arguments[0] as Property<*>).defaultValue })
+
+        // PluginDescriptionFile is final and so cannot be mocked
+        val descriptionFile = PluginDescriptionFile(
+                "PerWorldInventory", "N/A", PerWorldInventory::class.java.canonicalName)
+        val pluginLoader = JavaPluginLoader(server)
+        plugin = PerWorldInventory(pluginLoader, descriptionFile, pluginFolder, null)
+        setField(JavaPlugin::class, plugin, "logger", mock(PluginLogger::class.java))
+    }
+
+    @Test
+    fun shouldInitializeObjectsProperly() {
+        val injector = InjectorBuilder().addDefaultHandlers("me.ebonjaeger.perworldinventory").create()
+        injector.register(PerWorldInventory::class, plugin)
+        injector.register(Server::class, server)
+        injector.register(PluginManager::class, pluginManager)
+        injector.provide(PluginFolder::class, pluginFolder)
+        injector.provide(DataDirectory::class, File(pluginFolder, "data"))
+        injector.register(Settings::class, settings)
+        injector.registerProvider(DataSource::class, DataSourceProvider::class)
+
+        // when
+        plugin.injectServices(injector)
+
+        // then
+        assertThat(injector.getIfAvailable(GroupManager::class), not(nullValue()))
+        assertThat(injector.getIfAvailable(BukkitService::class), not(nullValue()))
+
+        verifyListenerWasRegistered(PlayerQuitListener::class, injector)
+        verifyListenerWasRegistered(InventoryCreativeListener::class, injector)
+        verifyListenerWasRegistered(PlayerTeleportListener::class, injector)
+    }
+
+    private fun verifyListenerWasRegistered(clazz: KClass<out Listener>, injector: Injector) {
+        val listener = injector.getIfAvailable(clazz)
+        assertThat("Listener available for $clazz", listener, not(nullValue()))
+        Mockito.verify(pluginManager).registerEvents(listener, plugin)
+    }
+
+    private fun <T: Any> setField(clazz: KClass<out T>, instance: T?, fieldName: String, value: Any?) {
+        val field = clazz.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(instance, value)
+    }
+}


### PR DESCRIPTION
I'm done bothering you for a while now :) This PR introduces a BukkitService and tries to make the `PerWorldInventory` instance a little dumber. I'd like to avoid the PWI instance to be injected everywhere, especially if it's just to get a folder.

Since you have a data directory and Bukkit calls the plugin's folder the "data folder", I try to avoid confusion by calling the Bukkit data folder "plugin folder" and your data directory always "data directory" (and not "data folder"). 