### PR TITLE
Economy to service

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -4,7 +4,6 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import me.ebonjaeger.perworldinventory.configuration.MetricsSettings
-import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
 import me.ebonjaeger.perworldinventory.configuration.PluginSettings
 import me.ebonjaeger.perworldinventory.configuration.Settings
 import me.ebonjaeger.perworldinventory.data.DataSource
@@ -19,7 +18,6 @@ import me.ebonjaeger.perworldinventory.listener.player.PlayerChangedWorldListene
 import me.ebonjaeger.perworldinventory.listener.player.PlayerQuitListener
 import me.ebonjaeger.perworldinventory.listener.player.PlayerTeleportListener
 import me.ebonjaeger.perworldinventory.permission.PermissionManager
-import net.milkbowl.vault.economy.Economy
 import org.bstats.bukkit.Metrics
 import org.bukkit.Bukkit
 import org.bukkit.Server
@@ -35,21 +33,6 @@ import java.util.*
 
 class PerWorldInventory : JavaPlugin
 {
-
-    /**
-     * Economy from Vault, if Vault is present on the server. If Vault is not
-     * installed or we failed to hook into it, this will return null.
-     */
-    var economy: Economy? = null
-        private set
-
-    /**
-     * If this is true, then Vault has been hooked in to, and the plugin is
-     * configured to perform economy operations on players. If either of
-     * those is not true, then this will return false.
-     */
-    var econEnabled = false
-        private set
 
     /**
      * Get whether or not the server is currently shutting down.
@@ -109,23 +92,6 @@ class PerWorldInventory : JavaPlugin
         injectServices(injector)
 
         ConsoleLogger.setUseDebug(settings.getProperty(PluginSettings.DEBUG_MODE))
-
-        // Register Vault if present
-        if (server.pluginManager.getPlugin("Vault") != null)
-        {
-            ConsoleLogger.info("Vault found! Hooking into it...")
-            val rsp = server.servicesManager.getRegistration(Economy::class.java)
-            if (rsp != null)
-            {
-                economy = rsp.provider
-                ConsoleLogger.info("Hooked into Vault!")
-            } else
-            {
-                ConsoleLogger.warning("Unable to hook into Vault!")
-            }
-        }
-
-        econEnabled = economy != null && settings.getProperty(PlayerSettings.USE_ECONOMY)
 
         // Start bStats metrics
         if (settings.getProperty(MetricsSettings.ENABLE_METRICS))

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProperty.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProperty.kt
@@ -1,0 +1,44 @@
+package me.ebonjaeger.perworldinventory.data
+
+import ch.jalu.configme.properties.Property
+import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import org.bukkit.entity.Player
+
+enum class PlayerProperty(private val property: Property<Boolean>,
+                          private val accessors: ValueAccessors<out Any>) {
+
+    ALLOW_FLIGHT(PlayerSettings.LOAD_ALLOW_FLIGHT,
+        ValueAccessors(Player::setAllowFlight, PlayerProfile::allowFlight)),
+
+    DISPLAY_NAME(PlayerSettings.LOAD_DISPLAY_NAME,
+        ValueAccessors(Player::setDisplayName, PlayerProfile::displayName)),
+
+    EXHAUSTION(PlayerSettings.LOAD_EXHAUSTION,
+        ValueAccessors(Player::setExhaustion, PlayerProfile::exhaustion)),
+
+    EXPERIENCE(PlayerSettings.LOAD_EXP,
+        ValueAccessors(Player::setExp, PlayerProfile::experience)),
+
+    FLYING(PlayerSettings.LOAD_FLYING,
+        ValueAccessors(Player::setFlying, PlayerProfile::isFlying)),
+
+    FOOD_LEVEL(PlayerSettings.LOAD_HUNGER,
+        ValueAccessors(Player::setFoodLevel, PlayerProfile::foodLevel));
+
+
+    fun applyFromProfileToPlayer(profile: PlayerProfile, player: Player, settings: Settings) {
+        if (settings.getProperty(property)) {
+            accessors.applyFromProfileToPlayer(profile, player)
+        }
+    }
+
+    private class ValueAccessors<T>(val playerSetter: (Player, T) -> Unit,
+                                    val profileGetter: (PlayerProfile) -> T) {
+
+        fun applyFromProfileToPlayer(profile: PlayerProfile, player: Player) {
+            val value = profileGetter(profile)
+            playerSetter(player, value)
+        }
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
@@ -1,25 +1,23 @@
 package me.ebonjaeger.perworldinventory.data
 
 import me.ebonjaeger.perworldinventory.service.BukkitService
+import me.ebonjaeger.perworldinventory.service.EconomyService
 import org.bukkit.entity.Player
+import javax.inject.Inject
 
 /**
  * Factory for creating PlayerProfile objects.
  *
  * @param bukkitService [BukkitService] instance
+ * @param economyService [EconomyService] instance
  */
-class ProfileFactory(private val bukkitService: BukkitService)
+class ProfileFactory @Inject constructor(private val bukkitService: BukkitService,
+                                         private val economyService: EconomyService)
 {
 
     fun create(player: Player): PlayerProfile
     {
-        var balance = 0.0
-        if (bukkitService.isEconEnabled())
-        {
-            val econ = bukkitService.getEconomy()
-            balance = econ!!.getBalance(player)
-        }
-
+        val balance = economyService.getBalance(player)
         return PlayerProfile(player, balance, bukkitService.shouldUseAttributes())
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
@@ -102,30 +102,11 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
             player.enderChest.clear()
             player.enderChest.contents = profile.enderChest
         }
-        if (settings.getProperty(PlayerSettings.LOAD_ALLOW_FLIGHT))
-        {
-            player.allowFlight = profile.allowFlight
+
+        for (value in PlayerProperty.values()) run {
+            value.applyFromProfileToPlayer(profile, player, settings)
         }
-        if (settings.getProperty(PlayerSettings.LOAD_DISPLAY_NAME))
-        {
-            player.displayName = profile.displayName
-        }
-        if (settings.getProperty(PlayerSettings.LOAD_EXHAUSTION))
-        {
-            player.exhaustion = profile.exhaustion
-        }
-        if (settings.getProperty(PlayerSettings.LOAD_EXP))
-        {
-            player.exp = profile.experience
-        }
-        if (settings.getProperty(PlayerSettings.LOAD_FLYING))
-        {
-            player.isFlying = profile.isFlying
-        }
-        if (settings.getProperty(PlayerSettings.LOAD_HUNGER))
-        {
-            player.foodLevel = profile.foodLevel
-        }
+
         // TODO: Put this in its own method
         if (settings.getProperty(PlayerSettings.LOAD_HEALTH))
         {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -15,14 +15,8 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
 
     private val scheduler = plugin.server.scheduler
 
-    fun isEconEnabled() =
-            plugin.econEnabled
-
     fun isShuttingDown() =
         plugin.isShuttingDown
-
-    fun getEconomy() =
-            plugin.economy
 
     fun getServerVersion() =
         plugin.server.version

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
@@ -1,0 +1,59 @@
+package me.ebonjaeger.perworldinventory.service
+
+import me.ebonjaeger.perworldinventory.ConsoleLogger
+import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import me.ebonjaeger.perworldinventory.data.PlayerProfile
+import net.milkbowl.vault.economy.Economy
+import org.bukkit.Server
+import org.bukkit.entity.Player
+import javax.annotation.PostConstruct
+import javax.inject.Inject
+
+class EconomyService @Inject constructor(private val server: Server,
+                                         private val settings: Settings) {
+
+    /**
+     * Economy from Vault, if Vault is present on the server. Null if Vault is not
+     * installed, we failed to hook into it, or PWI is configured not to use economy.
+     */
+    private var economy: Economy? = null
+
+    fun getBalance(player: Player): Double {
+        return if (economy != null) {
+            economy!!.getBalance(player)
+        } else {
+            0.0
+        }
+    }
+
+    fun overridePlayerBalanceFromProfile(player: Player, profile: PlayerProfile) {
+        val econ = economy
+        if (econ != null) {
+            econ.withdrawPlayer(player, econ.getBalance(player))
+            econ.depositPlayer(player, profile.balance)
+        }
+    }
+
+    fun withDrawMoneyFromPlayer(player: Player) {
+        if (economy != null) {
+            val amount = economy?.getBalance(player) ?: 0.0
+            economy?.withdrawPlayer(player, amount)
+        }
+    }
+
+    @PostConstruct
+    fun tryLoadEconomy() {
+        if (settings.getProperty(PlayerSettings.USE_ECONOMY) && server.pluginManager.getPlugin("Vault") != null) {
+            ConsoleLogger.info("Vault found! Hooking into it...")
+
+            val rsp = server.servicesManager.getRegistration(Economy::class.java)
+            if (rsp != null) {
+                economy = rsp.provider
+                ConsoleLogger.info("Hooked into Vault!")
+            } else {
+                ConsoleLogger.warning("Unable to hook into Vault!")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/service/EconomyServiceTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/service/EconomyServiceTest.kt
@@ -1,0 +1,125 @@
+package me.ebonjaeger.perworldinventory.service
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.present
+import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import me.ebonjaeger.perworldinventory.data.PlayerProfile
+import net.milkbowl.vault.economy.Economy
+import org.bukkit.Server
+import org.bukkit.entity.Player
+import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.PluginManager
+import org.bukkit.plugin.RegisteredServiceProvider
+import org.bukkit.plugin.ServicesManager
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+/**
+ * Test for [EconomyService].
+ */
+@PrepareForTest(Settings::class, PlayerProfile::class)
+@RunWith(PowerMockRunner::class)
+class EconomyServiceTest {
+
+    @InjectMocks
+    private lateinit var economyService: EconomyService
+
+    @Mock
+    private lateinit var server: Server
+    @Mock
+    private lateinit var settings: Settings
+    @Mock
+    private lateinit var pluginManager: PluginManager
+    @Mock
+    private lateinit var servicesManager: ServicesManager
+    @Mock
+    private lateinit var registeredServiceProvider: RegisteredServiceProvider<Economy>
+    @Mock
+    private lateinit var economy: Economy
+    @Mock
+    private lateinit var playerProfile: PlayerProfile
+
+    @Before
+    fun wireUpMocks() {
+        given(server.servicesManager).willReturn(servicesManager)
+        given(server.pluginManager).willReturn(pluginManager)
+        given(pluginManager.getPlugin("Vault")).willReturn(mock(Plugin::class.java))
+        given(servicesManager.getRegistration(Economy::class.java)).willReturn(registeredServiceProvider)
+        given(registeredServiceProvider.provider).willReturn(economy)
+    }
+
+    @Test
+    fun shouldInitializeEconomy() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+
+        // when
+        economyService.tryLoadEconomy()
+
+        // then
+        assertThat(getEconomyField(), present())
+    }
+
+    @Test
+    fun shouldNotInitializeEconomyIfSoConfigured() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(false)
+
+        // when
+        economyService.tryLoadEconomy()
+
+        // then
+        assertThat(getEconomyField(), absent())
+        verifyZeroInteractions(servicesManager, registeredServiceProvider)
+    }
+
+    @Test
+    fun shouldWithdrawFunds() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+        economyService.tryLoadEconomy()
+
+        val player = mock(Player::class.java)
+        given(economy.getBalance(player)).willReturn(320.0)
+
+        // when
+        economyService.withDrawMoneyFromPlayer(player)
+
+        // then
+        verify(economy).withdrawPlayer(player, 320.0)
+    }
+
+    @Test
+    fun shouldSetPlayerBalanceFromPlayerProfile() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+        economyService.tryLoadEconomy()
+
+        val player = mock(Player::class.java)
+        given(economy.getBalance(player)).willReturn(2.81)
+        given(playerProfile.balance).willReturn(1332.49)
+
+        // when
+        economyService.overridePlayerBalanceFromProfile(player, playerProfile)
+
+        // then
+        verify(economy).withdrawPlayer(player, 2.81)
+        verify(economy).depositPlayer(player, 1332.49)
+    }
+
+    private fun getEconomyField(): Economy? {
+        return economyService::class.java.getDeclaredField("economy").let {
+            it.isAccessible = true
+            return@let it.get(economyService) as Economy?
+        }
+    }
+}


### PR DESCRIPTION
Economy should be its own service:
- wrap the third-party class into the service
- economy service worries about checking whether it's enabled or not
- don't load any Economy stuff if it's configured to be disabled

I didn't find where economy is set from Player to PlayerProfile. But I'm also kinda drinking right now so I may be slipping. The method names on EconomyService could probably be improved. If you have better ideas please fix them or let me know.