### PR TITLE
Move economy matters into their own service

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -8,7 +8,6 @@ import me.ebonjaeger.perworldinventory.command.HelpCommand
 import me.ebonjaeger.perworldinventory.command.PWIBaseCommand
 import me.ebonjaeger.perworldinventory.command.ReloadCommand
 import me.ebonjaeger.perworldinventory.configuration.MetricsSettings
-import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
 import me.ebonjaeger.perworldinventory.configuration.PluginSettings
 import me.ebonjaeger.perworldinventory.configuration.Settings
 import me.ebonjaeger.perworldinventory.data.DataSource
@@ -18,10 +17,12 @@ import me.ebonjaeger.perworldinventory.initialization.DataDirectory
 import me.ebonjaeger.perworldinventory.initialization.Injector
 import me.ebonjaeger.perworldinventory.initialization.InjectorBuilder
 import me.ebonjaeger.perworldinventory.initialization.PluginFolder
-import me.ebonjaeger.perworldinventory.listener.player.*
 import me.ebonjaeger.perworldinventory.listener.entity.EntityPortalEventListener
+import me.ebonjaeger.perworldinventory.listener.player.InventoryCreativeListener
+import me.ebonjaeger.perworldinventory.listener.player.PlayerChangedWorldListener
+import me.ebonjaeger.perworldinventory.listener.player.PlayerQuitListener
+import me.ebonjaeger.perworldinventory.listener.player.PlayerTeleportListener
 import me.ebonjaeger.perworldinventory.permission.PermissionManager
-import net.milkbowl.vault.economy.Economy
 import org.bstats.bukkit.Metrics
 import org.bukkit.Bukkit
 import org.bukkit.Server
@@ -37,21 +38,6 @@ import java.util.*
 
 class PerWorldInventory : JavaPlugin
 {
-
-    /**
-     * Economy from Vault, if Vault is present on the server. If Vault is not
-     * installed or we failed to hook into it, this will return null.
-     */
-    var economy: Economy? = null
-        private set
-
-    /**
-     * If this is true, then Vault has been hooked in to, and the plugin is
-     * configured to perform economy operations on players. If either of
-     * those is not true, then this will return false.
-     */
-    var econEnabled = false
-        private set
 
     /**
      * Get whether or not the server is currently shutting down.
@@ -111,23 +97,6 @@ class PerWorldInventory : JavaPlugin
         injectServices(injector)
 
         ConsoleLogger.setUseDebug(settings.getProperty(PluginSettings.DEBUG_MODE))
-
-        // Register Vault if present
-        if (server.pluginManager.getPlugin("Vault") != null)
-        {
-            ConsoleLogger.info("Vault found! Hooking into it...")
-            val rsp = server.servicesManager.getRegistration(Economy::class.java)
-            if (rsp != null)
-            {
-                economy = rsp.provider
-                ConsoleLogger.info("Hooked into Vault!")
-            } else
-            {
-                ConsoleLogger.warning("Unable to hook into Vault!")
-            }
-        }
-
-        econEnabled = economy != null && settings.getProperty(PlayerSettings.USE_ECONOMY)
 
         val commandManager = BukkitCommandManager(this)
         commandManager.registerCommand(PWIBaseCommand())

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileFactory.kt
@@ -1,25 +1,23 @@
 package me.ebonjaeger.perworldinventory.data
 
 import me.ebonjaeger.perworldinventory.service.BukkitService
+import me.ebonjaeger.perworldinventory.service.EconomyService
 import org.bukkit.entity.Player
+import javax.inject.Inject
 
 /**
  * Factory for creating PlayerProfile objects.
  *
  * @param bukkitService [BukkitService] instance
+ * @param economyService [EconomyService] instance
  */
-class ProfileFactory(private val bukkitService: BukkitService)
+class ProfileFactory @Inject constructor(private val bukkitService: BukkitService,
+                                         private val economyService: EconomyService)
 {
 
     fun create(player: Player): PlayerProfile
     {
-        var balance = 0.0
-        if (bukkitService.isEconEnabled())
-        {
-            val econ = bukkitService.getEconomy()
-            balance = econ!!.getBalance(player)
-        }
-
+        val balance = economyService.getBalance(player)
         return PlayerProfile(player, balance, bukkitService.shouldUseAttributes())
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
@@ -8,6 +8,7 @@ import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
 import me.ebonjaeger.perworldinventory.configuration.PluginSettings
 import me.ebonjaeger.perworldinventory.configuration.Settings
 import me.ebonjaeger.perworldinventory.service.BukkitService
+import me.ebonjaeger.perworldinventory.service.EconomyService
 import org.bukkit.GameMode
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
@@ -16,7 +17,9 @@ import javax.inject.Inject
 
 class ProfileManager @Inject constructor(private val bukkitService: BukkitService,
                                          private val dataSource: DataSource,
-                                         private val settings: Settings)
+                                         private val settings: Settings,
+                                         private val economyService: EconomyService,
+                                         private val profileFactory: ProfileFactory)
 {
 
     private val profileCache: Cache<ProfileKey, PlayerProfile> = CacheBuilder.newBuilder()
@@ -24,7 +27,6 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
             .maximumSize(settings.getProperty(PluginSettings.CACHE_MAX_LIMIT).toLong())
             .build()
 
-    private val profileFactory = ProfileFactory(bukkitService)
     private val separateGameModes = settings.getProperty(PluginSettings.SEPARATE_GM_INVENTORIES)
 
     /**
@@ -196,15 +198,8 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         {
             player.remainingAir = profile.remainingAir
         }
-        if (bukkitService.isEconEnabled())
-        {
-            val economy = bukkitService.getEconomy()
-            if (economy != null)
-            {
-                economy.withdrawPlayer(player, economy.getBalance(player))
-                economy.depositPlayer(player, profile.balance)
-            }
-        }
+
+        economyService.overridePlayerBalanceFromProfile(player, profile)
     }
 
     /**
@@ -274,10 +269,7 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         {
             player.activePotionEffects.forEach { player.removePotionEffect(it.type) }
         }
-        if (bukkitService.isEconEnabled())
-        {
-            val amount = bukkitService.getEconomy()?.getBalance(player) ?: 0.0
-            bukkitService.getEconomy()?.withdrawPlayer(player, amount)
-        }
+
+        economyService.withDrawMoneyFromPlayer(player)
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -15,14 +15,8 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
 
     private val scheduler = plugin.server.scheduler
 
-    fun isEconEnabled() =
-            plugin.econEnabled
-
     fun isShuttingDown() =
         plugin.isShuttingDown
-
-    fun getEconomy() =
-            plugin.economy
 
     fun getServerVersion() =
         plugin.server.version

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/EconomyService.kt
@@ -1,0 +1,59 @@
+package me.ebonjaeger.perworldinventory.service
+
+import me.ebonjaeger.perworldinventory.ConsoleLogger
+import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import me.ebonjaeger.perworldinventory.data.PlayerProfile
+import net.milkbowl.vault.economy.Economy
+import org.bukkit.Server
+import org.bukkit.entity.Player
+import javax.annotation.PostConstruct
+import javax.inject.Inject
+
+class EconomyService @Inject constructor(private val server: Server,
+                                         private val settings: Settings) {
+
+    /**
+     * Economy from Vault, if Vault is present on the server. Null if Vault is not
+     * installed, we failed to hook into it, or PWI is configured not to use economy.
+     */
+    private var economy: Economy? = null
+
+    fun getBalance(player: Player): Double {
+        return if (economy != null) {
+            economy!!.getBalance(player)
+        } else {
+            0.0
+        }
+    }
+
+    fun overridePlayerBalanceFromProfile(player: Player, profile: PlayerProfile) {
+        val econ = economy
+        if (econ != null) {
+            econ.withdrawPlayer(player, econ.getBalance(player))
+            econ.depositPlayer(player, profile.balance)
+        }
+    }
+
+    fun withDrawMoneyFromPlayer(player: Player) {
+        if (economy != null) {
+            val amount = economy?.getBalance(player) ?: 0.0
+            economy?.withdrawPlayer(player, amount)
+        }
+    }
+
+    @PostConstruct
+    fun tryLoadEconomy() {
+        if (settings.getProperty(PlayerSettings.USE_ECONOMY) && server.pluginManager.getPlugin("Vault") != null) {
+            ConsoleLogger.info("Vault found! Hooking into it...")
+
+            val rsp = server.servicesManager.getRegistration(Economy::class.java)
+            if (rsp != null) {
+                economy = rsp.provider
+                ConsoleLogger.info("Hooked into Vault!")
+            } else {
+                ConsoleLogger.warning("Unable to hook into Vault!")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/service/EconomyServiceTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/service/EconomyServiceTest.kt
@@ -1,0 +1,125 @@
+package me.ebonjaeger.perworldinventory.service
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.present
+import me.ebonjaeger.perworldinventory.configuration.PlayerSettings
+import me.ebonjaeger.perworldinventory.configuration.Settings
+import me.ebonjaeger.perworldinventory.data.PlayerProfile
+import net.milkbowl.vault.economy.Economy
+import org.bukkit.Server
+import org.bukkit.entity.Player
+import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.PluginManager
+import org.bukkit.plugin.RegisteredServiceProvider
+import org.bukkit.plugin.ServicesManager
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+/**
+ * Test for [EconomyService].
+ */
+@PrepareForTest(Settings::class, PlayerProfile::class)
+@RunWith(PowerMockRunner::class)
+class EconomyServiceTest {
+
+    @InjectMocks
+    private lateinit var economyService: EconomyService
+
+    @Mock
+    private lateinit var server: Server
+    @Mock
+    private lateinit var settings: Settings
+    @Mock
+    private lateinit var pluginManager: PluginManager
+    @Mock
+    private lateinit var servicesManager: ServicesManager
+    @Mock
+    private lateinit var registeredServiceProvider: RegisteredServiceProvider<Economy>
+    @Mock
+    private lateinit var economy: Economy
+    @Mock
+    private lateinit var playerProfile: PlayerProfile
+
+    @Before
+    fun wireUpMocks() {
+        given(server.servicesManager).willReturn(servicesManager)
+        given(server.pluginManager).willReturn(pluginManager)
+        given(pluginManager.getPlugin("Vault")).willReturn(mock(Plugin::class.java))
+        given(servicesManager.getRegistration(Economy::class.java)).willReturn(registeredServiceProvider)
+        given(registeredServiceProvider.provider).willReturn(economy)
+    }
+
+    @Test
+    fun shouldInitializeEconomy() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+
+        // when
+        economyService.tryLoadEconomy()
+
+        // then
+        assertThat(getEconomyField(), present())
+    }
+
+    @Test
+    fun shouldNotInitializeEconomyIfSoConfigured() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(false)
+
+        // when
+        economyService.tryLoadEconomy()
+
+        // then
+        assertThat(getEconomyField(), absent())
+        verifyZeroInteractions(servicesManager, registeredServiceProvider)
+    }
+
+    @Test
+    fun shouldWithdrawFunds() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+        economyService.tryLoadEconomy()
+
+        val player = mock(Player::class.java)
+        given(economy.getBalance(player)).willReturn(320.0)
+
+        // when
+        economyService.withDrawMoneyFromPlayer(player)
+
+        // then
+        verify(economy).withdrawPlayer(player, 320.0)
+    }
+
+    @Test
+    fun shouldSetPlayerBalanceFromPlayerProfile() {
+        // given
+        given(settings.getProperty(PlayerSettings.USE_ECONOMY)).willReturn(true)
+        economyService.tryLoadEconomy()
+
+        val player = mock(Player::class.java)
+        given(economy.getBalance(player)).willReturn(2.81)
+        given(playerProfile.balance).willReturn(1332.49)
+
+        // when
+        economyService.overridePlayerBalanceFromProfile(player, playerProfile)
+
+        // then
+        verify(economy).withdrawPlayer(player, 2.81)
+        verify(economy).depositPlayer(player, 1332.49)
+    }
+
+    private fun getEconomyField(): Economy? {
+        return economyService::class.java.getDeclaredField("economy").let {
+            it.isAccessible = true
+            return@let it.get(economyService) as Economy?
+        }
+    }
+}


### PR DESCRIPTION
Economy should be its own service:
- wrap the third-party class into the service
- economy service worries about checking whether it's enabled or not
- don't load any Economy stuff if it's configured to be disabled

I didn't find where economy is set from Player to PlayerProfile. But I'm also kinda drinking right now so I may be slipping. The method names on EconomyService could probably be improved. If you have better ideas please fix them or let me know.