### PR TITLE
Teleporting to last location in group

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/PlayerSettings.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/configuration/PlayerSettings.kt
@@ -25,6 +25,11 @@ object PlayerSettings : SettingsHolder
     val LOAD_INVENTORY = newProperty("player.inventory", true)
 
     @JvmField
+    @Comment("Send players to their last location",
+            "Only happens if they're going to the same world they left")
+    val LOAD_LAST_LOCATION = newProperty("player.last-location", false)
+
+    @JvmField
     @Comment("Load if a player is able to fly")
     val LOAD_ALLOW_FLIGHT = newProperty("player.stats.can-fly", true)
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/FlatFile.kt
@@ -125,7 +125,7 @@ class FlatFile @Inject constructor(@DataDirectory private val dataDirectory: Fil
             val parser = JsonParser()
             val data = parser.parse(it).asJsonObject
 
-            return PlayerSerializer.deserialize(data)
+            return PlayerSerializer.deserialize(data, player.location)
         }
     }
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProfile.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/PlayerProfile.kt
@@ -1,6 +1,7 @@
 package me.ebonjaeger.perworldinventory.data
 
 import org.bukkit.GameMode
+import org.bukkit.Location
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -31,7 +32,8 @@ data class PlayerProfile constructor(val armor: Array<out ItemStack>,
                                      val fireTicks: Int,
                                      val maximumAir: Int,
                                      val remainingAir: Int,
-                                     val balance: Double)
+                                     val balance: Double,
+                                     val location: Location)
 {
 
     /**
@@ -62,7 +64,8 @@ data class PlayerProfile constructor(val armor: Array<out ItemStack>,
             player.fireTicks,
             player.maximumAir,
             player.remainingAir,
-            balance)
+            balance,
+            player.location)
 
     override fun equals(other: Any?): Boolean
     {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/data/ProfileManager.kt
@@ -12,6 +12,7 @@ import me.ebonjaeger.perworldinventory.service.EconomyService
 import org.bukkit.GameMode
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerTeleportEvent
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -100,6 +101,7 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         transferInventories(player, profile)
         transferHealth(player, profile)
         transferPotionEffects(player, profile)
+        transferLocation(player, profile)
 
         economyService.overridePlayerBalanceFromProfile(player, profile)
     }
@@ -141,6 +143,18 @@ class ProfileManager @Inject constructor(private val bukkitService: BukkitServic
         {
             player.activePotionEffects.forEach { player.removePotionEffect(it.type) }
             player.addPotionEffects(profile.potionEffects)
+        }
+    }
+
+    private fun transferLocation(player: Player, profile: PlayerProfile)
+    {
+        if (settings.getProperty(PlayerSettings.LOAD_LAST_LOCATION))
+        {
+            if (player.location.world == profile.location.world &&
+                    player.location != profile.location)
+            {
+                player.teleport(profile.location, PlayerTeleportEvent.TeleportCause.PLUGIN)
+            }
         }
     }
 

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/PlayerSerializer.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject
 import me.ebonjaeger.perworldinventory.ConsoleLogger
 import me.ebonjaeger.perworldinventory.data.PlayerProfile
 import org.bukkit.GameMode
+import org.bukkit.Location
 
 object PlayerSerializer
 {
@@ -34,12 +35,13 @@ object PlayerSerializer
         obj.add("inventory", InventorySerializer.serializeAllInventories(player))
         obj.add("stats", StatSerializer.serialize(player))
         obj.add("economy", EconomySerializer.serialize(player))
+        obj.add("location", LocationSerializer.serialize(player.location))
 
         ConsoleLogger.debug("[SERIALIZER] Done serializing player '${player.displayName}'")
         return obj
     }
 
-    fun deserialize(data: JsonObject): PlayerProfile
+    fun deserialize(data: JsonObject, spawnLoc: Location): PlayerProfile
     {
         // Get the data format being used
         var format = 2
@@ -48,7 +50,7 @@ object PlayerSerializer
             format = data["data-format"].asInt
         }
 
-        // TODO: Check server version as it might not have off-hand slot
+        // TODO: Do something other than hardcoded size number
         val inventory = InventorySerializer.deserialize(data["inventory"].asJsonArray,
                 37, // 27 storage slots, 9 hotbar slots, and an off-hand slot
                 format)
@@ -59,6 +61,13 @@ object PlayerSerializer
         val stats = data["stats"].asJsonObject
         val potionEffects = PotionSerializer.deserialize(stats["potion-effects"].asJsonArray)
         val balance = EconomySerializer.deserialize(data["economy"].asJsonObject)
+        val location = if (data.has("location"))
+        {
+            LocationSerializer.deserialize(data["location"].asJsonObject)
+        } else
+        {
+            spawnLoc
+        }
 
         return PlayerProfile(armor,
                 enderChest,
@@ -79,6 +88,7 @@ object PlayerSerializer
                 stats["fireTicks"].asInt,
                 stats["maxAir"].asInt,
                 stats["remainingAir"].asInt,
-                balance)
+                balance,
+                location)
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,9 @@ player:
   ender-chest: true
   # Load players' inventory
   inventory: true
+  # Send players to their last location
+  # Only happens if they're going to the same world they left
+  last-location: false
   # All options for player stats are here:
   stats:
     # Load if a player is able to fly


### PR DESCRIPTION
I doubt I'll ever want to actually merge this, but I would like input and thoughts from @ljacqu and @BeatlesDev.

One much requested feature in PWI can be seen with Gnat008/PerWorldInventory#108. Thinking about the various edge cases means this can get really complicated really fast, however. On top of that, I don't really agree that dealing with locations is within the scope of PWI; it should be in the multi-world plugin, imo.

So, here we are. Currently in this branch, we save the location with the rest of the player, meaning we only have their last location inside of any given Group. It kind of feels a bit janky, as of now. The DataSource class has methods implemented already for saving/getting the last location in _any_ world, so maybe if we do decide to mess with locations, using those would be better. My thought was not to have to do another database call to get _another_ piece of data on every group or world change.

Again, do not merge this as-is!