### PR TITLE
Implement converting from Multiverse-Inventories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,15 @@
             <id>bstats-repo</id>
             <url>http://repo.bstats.org/content/repositories/releases/</url>
         </repository>
+
         <repository>
             <id>aikar</id>
             <url>https://repo.aikar.co/content/groups/aikar/</url>
+        </repository>
+
+        <repository>
+            <id>onarandombox</id>
+            <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
     </repositories>
 
@@ -135,6 +141,27 @@
             </exclusions>
         </dependency>
 
+        <!-- MultiVerse-Inventories -->
+        <dependency>
+            <groupId>com.onarandombox.multiverseinventories</groupId>
+            <artifactId>Multiverse-Inventories</artifactId>
+            <version>2.5</version>
+            <type>jar</type>
+            <scope>provided</scope>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>net.milkbowl.vault</groupId>
+                    <artifactId>Vault</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- bStats -->
         <dependency>
             <groupId>org.bstats</groupId>
@@ -172,6 +199,12 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nhaarman</groupId>
+            <artifactId>mockito-kotlin</artifactId>
+            <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import me.ebonjaeger.perworldinventory.api.PerWorldInventoryAPI
+import me.ebonjaeger.perworldinventory.command.ConvertCommand
 import me.ebonjaeger.perworldinventory.command.HelpCommand
 import me.ebonjaeger.perworldinventory.command.PWIBaseCommand
 import me.ebonjaeger.perworldinventory.command.ReloadCommand
@@ -105,6 +106,7 @@ class PerWorldInventory : JavaPlugin
         commandManager.registerCommand(PWIBaseCommand())
         commandManager.registerCommand(HelpCommand(this))
         commandManager.registerCommand(injector.getSingleton(ReloadCommand::class))
+        commandManager.registerCommand(injector.getSingleton(ConvertCommand::class))
 
         // Start bStats metrics
         if (settings.getProperty(MetricsSettings.ENABLE_METRICS))

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/ConvertCommand.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/ConvertCommand.kt
@@ -4,6 +4,7 @@ import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandPermission
 import co.aikar.commands.annotation.Description
 import co.aikar.commands.annotation.Subcommand
+import com.onarandombox.multiverseinventories.MultiverseInventories
 import me.ebonjaeger.perworldinventory.conversion.ConvertService
 import org.bukkit.ChatColor
 import org.bukkit.command.CommandSender
@@ -27,6 +28,14 @@ class ConvertCommand @Inject constructor(private val pluginManager: PluginManage
             return
         }
 
-        convertService.runConversion(sender)
+        val mvi = pluginManager.getPlugin("Multiverse-Inventories")
+        if (mvi == null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}" +
+                    "Unable to get Multiverse-Inventories instance!")
+            return
+        }
+
+        convertService.runConversion(sender, mvi as MultiverseInventories)
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/ConvertCommand.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/ConvertCommand.kt
@@ -1,0 +1,32 @@
+package me.ebonjaeger.perworldinventory.command
+
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Description
+import co.aikar.commands.annotation.Subcommand
+import me.ebonjaeger.perworldinventory.conversion.ConvertService
+import org.bukkit.ChatColor
+import org.bukkit.command.CommandSender
+import org.bukkit.plugin.PluginManager
+import javax.inject.Inject
+
+@CommandAlias("perworldinventory|pwi")
+class ConvertCommand @Inject constructor(private val pluginManager: PluginManager,
+                                         private val convertService: ConvertService) : PWIBaseCommand()
+{
+
+    @Subcommand("convert")
+    @CommandPermission("perworldinventory.convert")
+    @Description("Convert inventory data from another plugin")
+    fun onConvert(sender: CommandSender)
+    {
+        if (!pluginManager.isPluginEnabled("Multiverse-Inventories"))
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}" +
+                    "Multiverse-Inventories is not installed! Cannot convert data!")
+            return
+        }
+
+        convertService.runConversion(sender)
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertExecutor.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertExecutor.kt
@@ -1,0 +1,151 @@
+package me.ebonjaeger.perworldinventory.conversion
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.onarandombox.multiverseinventories.ProfileTypes
+import com.onarandombox.multiverseinventories.api.profile.PlayerProfile
+import com.onarandombox.multiverseinventories.api.profile.WorldGroupProfile
+import com.onarandombox.multiverseinventories.api.share.Sharables
+import me.ebonjaeger.perworldinventory.ConsoleLogger
+import me.ebonjaeger.perworldinventory.Group
+import me.ebonjaeger.perworldinventory.GroupManager
+import me.ebonjaeger.perworldinventory.initialization.DataDirectory
+import me.ebonjaeger.perworldinventory.serialization.InventorySerializer
+import me.ebonjaeger.perworldinventory.serialization.PotionSerializer
+import org.bukkit.GameMode
+import org.bukkit.OfflinePlayer
+import org.bukkit.potion.PotionEffect
+import java.io.File
+import java.io.FileWriter
+import java.nio.file.Files
+import java.util.*
+import javax.inject.Inject
+
+/**
+ * Class that performs converting operations.
+ */
+class ConvertExecutor @Inject constructor(private val groupManager: GroupManager,
+                                          @DataDirectory private val dataDirectory: File)
+{
+
+    var mvGroups: List<WorldGroupProfile>? = null
+
+    /**
+     * Converts data from the MultiVerse-Inventories format to the PWI format.
+     *
+     * @param player The player to convert.
+     */
+    fun executeConvert(player: OfflinePlayer)
+    {
+        val profileTypes = arrayOf(ProfileTypes.ADVENTURE,
+                ProfileTypes.CREATIVE,
+                ProfileTypes.SURVIVAL)
+        val gson = Gson()
+
+        if (mvGroups == null)
+        {
+            throw IllegalStateException("Trying to convert with no groups from MV-I")
+        }
+
+        mvGroups!!.forEach { mvGroup ->
+            val ourGroup = groupManager.getGroup(mvGroup.name)
+            if (ourGroup == null)
+            {
+                ConsoleLogger.warning("Trying to convert to a group that doesn't exist! " +
+                        "Not converting to group '${mvGroup.name}'!")
+                return
+            }
+
+            profileTypes.forEach { type ->
+                val gameMode = GameMode.valueOf(type.name)
+
+                try
+                {
+                    val playerProfile = mvGroup.getPlayerData(type, player)
+                    if (playerProfile != null)
+                    {
+                        val data = convertData(playerProfile)
+                        val file = getFile(player.uniqueId, gameMode, ourGroup)
+
+                        if (!file.parentFile.exists())
+                            Files.createDirectory(file.parentFile.toPath())
+                        if (!file.exists())
+                            Files.createFile(file.toPath())
+
+                        FileWriter(file).use { it.write(gson.toJson(data)) }
+                    }
+                } catch (ex: Exception)
+                {
+                    ConsoleLogger.severe("Error converting data for '${player.name}' " +
+                            "with group '${ourGroup.name}' for GameMode '$gameMode", ex)
+                }
+            }
+        }
+    }
+
+    private fun convertData(profile: PlayerProfile): JsonObject
+    {
+        val obj = JsonObject()
+        obj.addProperty("data-format", 2)
+
+        // Inventory and armor
+        val inventory = JsonObject()
+        if (profile[Sharables.INVENTORY] != null)
+            inventory.add("inventory", InventorySerializer.serializeInventory(profile[Sharables.INVENTORY]))
+        if (profile[Sharables.ARMOR] != null)
+            inventory.add("armor", InventorySerializer.serializeInventory(profile[Sharables.ARMOR]))
+
+        obj.add("inventory", inventory)
+
+        // Ender chest
+        if (profile[Sharables.ENDER_CHEST] != null)
+            obj.add("ender-chest", InventorySerializer.serializeInventory(profile[Sharables.ENDER_CHEST]))
+
+        // Player stats
+        val stats = JsonObject()
+        if (profile[Sharables.EXHAUSTION] != null)
+            stats.addProperty("exhaustion", profile[Sharables.EXHAUSTION])
+        if (profile[Sharables.EXPERIENCE] != null)
+            stats.addProperty("experience", profile[Sharables.EXPERIENCE])
+        if (profile[Sharables.FOOD_LEVEL] != null)
+            stats.addProperty("food", profile[Sharables.FOOD_LEVEL])
+        if (profile[Sharables.HEALTH] != null)
+            stats.addProperty("health", profile[Sharables.HEALTH])
+        if (profile[Sharables.LEVEL] != null)
+            stats.addProperty("level", profile[Sharables.LEVEL])
+        if (profile[Sharables.POTIONS] != null)
+        {
+            val effects = mutableListOf<PotionEffect>()
+            effects.addAll(profile[Sharables.POTIONS])
+            stats.add("potion-effects", PotionSerializer.serialize(effects))
+        }
+        if (profile[Sharables.SATURATION] != null)
+            stats.addProperty("saturation", profile[Sharables.SATURATION])
+        if (profile[Sharables.FALL_DISTANCE] != null)
+            stats.addProperty("fallDistance", profile[Sharables.FALL_DISTANCE])
+        if (profile[Sharables.FIRE_TICKS] != null)
+            stats.addProperty("fireTicks", profile[Sharables.FIRE_TICKS])
+        if (profile[Sharables.MAXIMUM_AIR] != null)
+            stats.addProperty("maxAir", profile[Sharables.MAXIMUM_AIR])
+        if (profile[Sharables.REMAINING_AIR] != null)
+            stats.addProperty("remainingAir", profile[Sharables.REMAINING_AIR])
+
+        obj.add("stats", stats)
+
+        // Economy stuffs
+        if (profile[Sharables.ECONOMY] != null)
+        {
+            val econ = JsonObject()
+            econ.addProperty("balance", profile[Sharables.ECONOMY])
+            obj.add("economy", econ)
+        }
+
+        return obj
+    }
+
+    private fun getFile(uuid: UUID, gameMode: GameMode, group: Group): File
+    {
+        val userDir = File(dataDirectory, uuid.toString())
+        return File(userDir, "${group.name}_${gameMode.toString().toLowerCase()}")
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
@@ -14,9 +14,9 @@ import javax.inject.Inject
  * Initiates conversion tasks.
  */
 class ConvertService @Inject constructor(private val bukkitService: BukkitService,
-                                              private val convertExecutor: ConvertExecutor,
-                                              private val groupManager: GroupManager,
-                                              private val pluginManager: PluginManager)
+                                         private val convertExecutor: ConvertExecutor,
+                                         private val groupManager: GroupManager,
+                                         private val pluginManager: PluginManager)
 {
 
     /**
@@ -27,16 +27,8 @@ class ConvertService @Inject constructor(private val bukkitService: BukkitServic
      */
     var converting = false
 
-    fun runConversion(sender: CommandSender)
+    fun runConversion(sender: CommandSender, mvinventory: MultiverseInventories)
     {
-        val mvinventory = pluginManager.getPlugin("Multiverse-Inventories") as MultiverseInventories
-        if (mvinventory == null)
-        {
-            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}" +
-                    "Multiverse-Inventories is not currently installed! Cannot convert!")
-            return
-        }
-
         val offlinePlayers = bukkitService.getOfflinePlayers()
         convertPlayers(sender, offlinePlayers, mvinventory)
     }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
@@ -1,0 +1,90 @@
+package me.ebonjaeger.perworldinventory.conversion
+
+import com.onarandombox.multiverseinventories.MultiverseInventories
+import me.ebonjaeger.perworldinventory.GroupManager
+import me.ebonjaeger.perworldinventory.service.BukkitService
+import org.bukkit.ChatColor
+import org.bukkit.GameMode
+import org.bukkit.OfflinePlayer
+import org.bukkit.command.CommandSender
+import org.bukkit.plugin.PluginManager
+import javax.inject.Inject
+
+/**
+ * Initiates conversion tasks.
+ */
+open class ConvertService @Inject constructor(private val bukkitService: BukkitService,
+                                              private val convertExecutor: ConvertExecutor,
+                                              private val groupManager: GroupManager,
+                                              private val pluginManager: PluginManager)
+{
+
+    /**
+     * Conversion status.
+     *
+     * If this is true, then a conversion is currently in progress,
+     * and another conversion cannot be started.
+     */
+    var converting = false
+
+    fun runConversion(sender: CommandSender)
+    {
+        val mvinventory = pluginManager.getPlugin("Multiverse-Inventories") as MultiverseInventories
+        if (mvinventory == null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}" +
+                    "Multiverse-Inventories is not currently installed! Cannot convert!")
+            return
+        }
+
+        val offlinePlayers = bukkitService.getOfflinePlayers()
+        convertPlayers(sender, offlinePlayers, mvinventory)
+    }
+
+    private fun convertPlayers(sender: CommandSender,
+                               offlinePlayers: Array<out OfflinePlayer>,
+                               mvinventory: MultiverseInventories)
+    {
+        if (converting)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}" +
+                    "A conversion is already in progress!")
+            return
+        }
+
+        converting = true
+        val mvGroups = mvinventory.groupManager.groups
+        convertExecutor.mvGroups = mvGroups
+
+        mvGroups.forEach {
+            // Ensure that the group exists first, otherwise you get nulls down the road
+            val pwiGroup = groupManager.getGroup(it.name)
+            val worlds = it.worlds
+
+            if (pwiGroup == null)
+            {
+                groupManager.addGroup(it.name, worlds, GameMode.SURVIVAL)
+            } else
+            {
+                pwiGroup.addWorlds(worlds)
+            }
+        }
+
+        val task = ConvertTask(this, sender, offlinePlayers)
+        bukkitService.runRepeatingTaskAsynchronously(task, 0, 1)
+    }
+
+    fun disableMVI()
+    {
+        val mvinventory = pluginManager.getPlugin("Multiverse-Inventories")
+        if (mvinventory != null && pluginManager.isPluginEnabled(mvinventory))
+        {
+            pluginManager.disablePlugin(mvinventory)
+        }
+    }
+
+    fun executeConvert(batch: Collection<OfflinePlayer>)
+    {
+        batch.forEach(convertExecutor::executeConvert)
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 /**
  * Initiates conversion tasks.
  */
-open class ConvertService @Inject constructor(private val bukkitService: BukkitService,
+class ConvertService @Inject constructor(private val bukkitService: BukkitService,
                                               private val convertExecutor: ConvertExecutor,
                                               private val groupManager: GroupManager,
                                               private val pluginManager: PluginManager)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTask.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTask.kt
@@ -1,0 +1,66 @@
+package me.ebonjaeger.perworldinventory.conversion
+
+import org.bukkit.ChatColor
+import org.bukkit.OfflinePlayer
+import org.bukkit.command.CommandSender
+import org.bukkit.scheduler.BukkitRunnable
+
+/**
+ * Task to convert player data from MultiVerse-Inventories to PWI.
+ *
+ * @property convertService The [ConvertService] running this task.
+ * @property sender The [CommandSender] that started the conversion.
+ * @property offlinePlayers All [OfflinePlayer]s on the server.
+ */
+class ConvertTask (private val convertService: ConvertService,
+                   private val sender: CommandSender,
+                   private val offlinePlayers: Array<out OfflinePlayer>) : BukkitRunnable()
+{
+
+    private val CONVERTS_PER_TICK = 5
+
+    private var currentPage = 0
+
+    override fun run()
+    {
+        val stopIndex = currentPage * CONVERTS_PER_TICK + CONVERTS_PER_TICK
+        var currentIndex = currentPage * CONVERTS_PER_TICK
+
+        if (currentIndex >= offlinePlayers.size)
+        {
+            finish()
+            return
+        }
+
+        val playersInPage = mutableSetOf<OfflinePlayer>()
+        while (currentIndex < stopIndex && currentIndex < offlinePlayers.size)
+        {
+            playersInPage.add(offlinePlayers[currentIndex])
+            currentIndex++
+        }
+
+        currentPage++
+
+        convertService.executeConvert(playersInPage)
+        if (currentPage % 20 == 0)
+        {
+            sender.sendMessage("${ChatColor.BLUE}» ${ChatColor.GRAY}Convert progress: " +
+                    "$stopIndex/${offlinePlayers.size}")
+        }
+    }
+
+    private fun finish()
+    {
+        cancel()
+
+        sender.sendMessage("${ChatColor.BLUE}» ${ChatColor.GRAY}Conversion has " +
+                "been completed! Disabling MultiVerse-Inventories...")
+
+        convertService.disableMVI()
+
+        sender.sendMessage("${ChatColor.BLUE}» ${ChatColor.GRAY}" +
+                "MultiVerse-Inventories disabled! Don't forget to remove the .jar!")
+
+        convertService.converting = false
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -2,6 +2,7 @@ package me.ebonjaeger.perworldinventory.service
 
 import me.ebonjaeger.perworldinventory.PerWorldInventory
 import me.ebonjaeger.perworldinventory.Utils
+import org.bukkit.Bukkit
 import org.bukkit.scheduler.BukkitTask
 import javax.inject.Inject
 
@@ -18,8 +19,14 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
     fun isShuttingDown() =
         plugin.isShuttingDown
 
+    fun getOfflinePlayers() =
+            Bukkit.getOfflinePlayers()
+
     fun getServerVersion() =
         plugin.server.version
+
+    fun runRepeatingTaskAsynchronously(task: Runnable, delay: Long, period: Long) =
+            scheduler.runTaskTimerAsynchronously(plugin, task, delay, period)
 
     fun runTaskAsynchronously(task: () -> Unit) =
         scheduler.runTaskAsynchronously(plugin, task)

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/ReflectionUtils.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/ReflectionUtils.kt
@@ -1,0 +1,44 @@
+package me.ebonjaeger.perworldinventory
+
+import java.lang.String.format
+import java.lang.reflect.Field
+import kotlin.reflect.KClass
+
+object ReflectionUtils
+{
+
+    /**
+     * Set the field of a given object to a new value with reflection.
+     *
+     * @param clazz The class of the object.
+     * @param instance The instance to modify (null for static fields).
+     * @param fieldName The name of the field to modify.
+     * @param value The value to give the field.
+     */
+    fun <T: Any> setField(clazz: KClass<T>, instance: T?, fieldName: String, value: Any)
+    {
+        try
+        {
+            val field = getField(clazz, instance, fieldName)
+            field.set(instance, value)
+        } catch (ex: UnsupportedOperationException)
+        {
+            throw UnsupportedOperationException(format("Could not set field '%s' for instance '%s' of class '%s'.",
+                    fieldName, instance, clazz.simpleName), ex)
+        }
+    }
+
+    private fun <T: Any> getField(clazz: KClass<T>, instance: T?, fieldName: String): Field
+    {
+        try
+        {
+            val field = clazz.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            return field
+        } catch (ex: NoSuchFieldException)
+        {
+            throw UnsupportedOperationException(format("Could not get field '%s' for instance '%s' of class '%s'.",
+                    fieldName, instance, clazz.simpleName), ex)
+        }
+    }
+}

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
@@ -1,0 +1,58 @@
+package me.ebonjaeger.perworldinventory.conversion
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import org.bukkit.OfflinePlayer
+import org.bukkit.command.CommandSender
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.powermock.modules.junit4.PowerMockRunner
+
+/**
+ * Tests for [ConvertTask].
+ */
+@RunWith(PowerMockRunner::class)
+class ConvertTaskTest
+{
+
+    private val convertService = mock(ConvertService::class.java)
+
+    @Test
+    fun shouldRunTask()
+    {
+        // given
+        val players = arrayOf(
+                mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java),
+                mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java))
+        reset(convertService)
+        val task = ConvertTask(convertService, mock(CommandSender::class.java), players)
+
+        // when (1 - first run, 5 players per run)
+        task.run()
+
+        // then (1)
+        // In the first run, only the first five should be converted
+        assertRanConvertWithPlayers(players[0], players[1], players[2], players[3], players[4])
+
+        // when (2)
+        reset(convertService)
+        task.run()
+
+        // then (2)
+        // The last player should now be converted
+        assertRanConvertWithPlayers(players[5])
+    }
+
+    private fun assertRanConvertWithPlayers(vararg players: OfflinePlayer)
+    {
+        argumentCaptor<Collection<OfflinePlayer>>().apply {
+            verify(convertService).executeConvert(capture())
+            assertThat(lastValue.size, equalTo(players.size))
+            //lastValue.forEach { assertThat(players, hasItem(it)) }
+        }
+    }
+}

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
@@ -35,7 +35,7 @@ class ConvertTaskTest
         val players = arrayOf(
                 mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java),
                 mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java), mock(OfflinePlayer::class.java))
-        reset(convertService)
+
         val task = ConvertTask(convertService, mock(CommandSender::class.java), players)
 
         // when (1 - first run, 5 players per run)

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
@@ -3,19 +3,22 @@ package me.ebonjaeger.perworldinventory.conversion
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.atLeastOnce
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
+import org.powermock.api.mockito.PowerMockito.mock
+import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
 
 /**
  * Tests for [ConvertTask].
  */
 @RunWith(PowerMockRunner::class)
+@PrepareForTest(ConvertService::class)
 class ConvertTaskTest
 {
 
@@ -50,7 +53,7 @@ class ConvertTaskTest
     private fun assertRanConvertWithPlayers(vararg players: OfflinePlayer)
     {
         argumentCaptor<Collection<OfflinePlayer>>().apply {
-            verify(convertService).executeConvert(capture())
+            verify(convertService, atLeastOnce()).executeConvert(capture())
             assertThat(lastValue.size, equalTo(players.size))
             //lastValue.forEach { assertThat(players, hasItem(it)) }
         }

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTaskTest.kt
@@ -81,7 +81,7 @@ class ConvertTaskTest
         argumentCaptor<Collection<OfflinePlayer>>().apply {
             verify(convertService, atLeastOnce()).executeConvert(capture())
             assertThat(lastValue.size, equalTo(players.size))
-            //lastValue.forEach { assertThat(players, hasItem(it)) }
+            lastValue.forEach { assert(players.contains(it)) }
         }
     }
 }


### PR DESCRIPTION
This is a re-implementation of the converter overhaul I started in the Java version last year but never landed ( https://github.com/Gnat008/PerWorldInventory/pull/176 ).

It will convert all players in batches of five. This is to help large imports actually finish instead of running out of resources and crashing the servers.

As per the history in that PR, there may still be unknown issues with running out of memory or threads.