### PR TITLE
Implement commands to modify groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,18 @@
             <version>0.9.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>1.2.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>1.2.20</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- Project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.jdkVersion>1.8</project.jdkVersion>
-        <kotlin.version>1.2.30</kotlin.version>
+        <kotlin.version>1.2.31</kotlin.version>
 
         <!-- Output properties -->
         <project.outputName>PerWorldInventory</project.outputName>

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/Group.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/Group.kt
@@ -56,6 +56,16 @@ data class Group(val name: String,
         worlds.add(world)
     }
 
+    /**
+     * Remove a world from this group.
+     *
+     * @param world The name of the world to remove
+     */
+    fun removeWorld(world: String)
+    {
+        worlds.remove(world)
+    }
+
     override fun equals(other: Any?): Boolean
     {
         if (this === other) return true

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -32,7 +32,7 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
     {
         val group = Group(name, worlds, gameMode)
         ConsoleLogger.debug("Adding group to memory: $group")
-        groups.put(name.toLowerCase(), group)
+        groups[name.toLowerCase()] = group
     }
 
     /**
@@ -66,11 +66,22 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
         // If we reach this point, the group doesn't yet exist.
         val worlds = mutableSetOf(world, "${world}_nether", "${world}_the_end")
         val group = Group(world, worlds, GameMode.SURVIVAL)
-        groups.put(world.toLowerCase(), group)
+        groups[world.toLowerCase()] = group
         ConsoleLogger.warning("Creating a new group on the fly for '$world'." +
                 " Please double check your `worlds.json` file configuration!")
 
         return group
+    }
+
+    /**
+     * Remove a world group.
+     *
+     * @param group The name of the group to remove
+     */
+    fun removeGroup(group: String)
+    {
+        groups.remove(group.toLowerCase())
+        ConsoleLogger.debug("Removed group '$group'")
     }
 
     /**

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -140,8 +140,10 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
 
         root.add("groups", groups)
 
-        FileWriter(WORLDS_CONFIG_FILE).use {
-            it.write(gson.toJson(root))
-        }
+        bukkitService.runTaskOptionallyAsynchronously({
+            FileWriter(WORLDS_CONFIG_FILE).use {
+                it.write(gson.toJson(root))
+            }
+        }, !bukkitService.isShuttingDown())
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/PerWorldInventory.kt
@@ -5,10 +5,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import me.ebonjaeger.perworldinventory.api.PerWorldInventoryAPI
-import me.ebonjaeger.perworldinventory.command.ConvertCommand
-import me.ebonjaeger.perworldinventory.command.HelpCommand
-import me.ebonjaeger.perworldinventory.command.PWIBaseCommand
-import me.ebonjaeger.perworldinventory.command.ReloadCommand
+import me.ebonjaeger.perworldinventory.command.*
 import me.ebonjaeger.perworldinventory.configuration.MetricsSettings
 import me.ebonjaeger.perworldinventory.configuration.PluginSettings
 import me.ebonjaeger.perworldinventory.configuration.Settings
@@ -33,6 +30,8 @@ import java.io.File
 import java.io.FileWriter
 import java.nio.file.Files
 import java.util.*
+
+
 
 class PerWorldInventory : JavaPlugin
 {
@@ -95,7 +94,7 @@ class PerWorldInventory : JavaPlugin
         // Inject and register all the things
         setupGroupManager(injector)
         injectServices(injector)
-        registerCommands(injector)
+        registerCommands(injector, injector.getSingleton(GroupManager::class))
 
         // Start bStats metrics
         if (settings.getProperty(MetricsSettings.ENABLE_METRICS))
@@ -159,13 +158,18 @@ class PerWorldInventory : JavaPlugin
         api = injector.getSingleton(PerWorldInventoryAPI::class)
     }
 
-    private fun registerCommands(injector: Injector)
+    private fun registerCommands(injector: Injector, groupManager: GroupManager)
     {
         val commandManager = PaperCommandManager(this)
+
+        commandManager.commandCompletions.registerAsyncCompletion(
+                "@groups", { groupManager.groups.keys })
+
         commandManager.registerCommand(PWIBaseCommand())
         commandManager.registerCommand(HelpCommand(this))
         commandManager.registerCommand(injector.getSingleton(ReloadCommand::class))
         commandManager.registerCommand(injector.getSingleton(ConvertCommand::class))
+        commandManager.registerCommand(injector.getSingleton(GroupCommands::class))
     }
 
     /**

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
@@ -1,0 +1,156 @@
+package me.ebonjaeger.perworldinventory.command
+
+import co.aikar.commands.annotation.*
+import me.ebonjaeger.perworldinventory.GroupManager
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
+import org.bukkit.GameMode
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import javax.inject.Inject
+
+@CommandAlias("perworldinventory|pwi")
+class GroupCommands @Inject constructor(private val groupManager: GroupManager) : PWIBaseCommand()
+{
+
+    @Subcommand("listgroups")
+    @CommandPermission("perworldinventory.command.groups.list")
+    @Description("Shows all of the current group names")
+    fun onListGroups(sender: CommandSender)
+    {
+        sender.sendMessage("${ChatColor.DARK_GRAY}                [ ${ChatColor.BLUE}PerWorldInventory Groups ${ChatColor.DARK_GRAY}]")
+        for (i in 0 until groupManager.groups.keys.size)
+        {
+            val key = groupManager.groups.keys.elementAt(i)
+            sender.sendMessage("${ChatColor.BLUE} $i${ChatColor.GRAY}: $key")
+        }
+    }
+
+    @Subcommand("addgroup")
+    @CommandPermission("perworldinventory.command.groups.add")
+    @Description("Add a new world group")
+    fun onAddGroup(sender: CommandSender, name: String, @Default("SURVIVAL") defaultGameMode: String, vararg worlds: String)
+    {
+        // Check if this group already exists
+        if (groupManager.getGroup(name) != null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}A group called '$name' already exists!")
+            return
+        }
+
+        // Get the GameMode
+        val gameMode = try
+        {
+            GameMode.valueOf(defaultGameMode.toUpperCase())
+        } catch (ex: IllegalArgumentException)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}'$defaultGameMode' is not a valid GameMode!")
+            return
+        }
+
+        groupManager.addGroup(name, worlds.toMutableSet(), gameMode)
+        groupManager.saveGroups()
+        sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group created successfully!")
+    }
+
+    @Subcommand("addworld")
+    @CommandPermission("perworldinventory.command.groups.modify")
+    @Description("Add a world to a group")
+    @CommandCompletion("@groups @worlds")
+    fun onAddWorld(sender: CommandSender, groupName: String, @Optional world: String)
+    {
+        val group = groupManager.getGroup(groupName)
+
+        // Check if the group exists
+        if (group == null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No group with that name exists!")
+            return
+        }
+
+        var worldName = world
+
+        // Check if the sender specified a world, and if that world exists
+        if (world != null && Bukkit.getWorld(world) == null)
+        {
+            // User specified a world, but it doesn't exist
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world with that name exists!")
+            return
+        } else if (world == null) // Else, get the world from the sender's current location
+        {
+            if (sender !is Player)
+            {
+                sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Must be a player to execute this command without a world!")
+                return
+            }
+
+            worldName = sender.location.world.name
+        }
+
+        group.addWorld(worldName)
+        groupManager.saveGroups()
+        sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Added the world '$worldName' to group '$groupName'!")
+    }
+
+    @Subcommand("removegroup")
+    @CommandPermission("perworldinventory.command.groups.remove")
+    @Description("Remove a group")
+    fun onRemoveGroup(sender: CommandSender, group: String)
+    {
+        if (groupManager.getGroup(group) == null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No group with that name exists!")
+            return
+        }
+
+        groupManager.removeGroup(group)
+        groupManager.saveGroups()
+        sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group removed successfully!")
+    }
+
+    @Subcommand("removeworld")
+    @CommandPermission("perworldinventory.command.groups.modify")
+    @Description("Remove a world from a group")
+    @CommandCompletion("@groups @worlds")
+    fun onRemoveWorld(sender: CommandSender, groupName: String, @Optional world: String)
+    {
+        val group = groupManager.getGroup(groupName)
+
+        // Check if the group exists
+        if (group == null)
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No group with that name exists!")
+            return
+        }
+
+        var worldName = world
+
+        // Check if the sender specified a world, and if that world exists
+        if (world != null && Bukkit.getWorld(world) == null)
+        {
+            // User specified a world, but it doesn't exist
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world with that name exists!")
+            return
+        } else if (world == null) // Else, get the world from the sender's current location
+        {
+            if (sender !is Player)
+            {
+                sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}Must be a player to execute this command without a world!")
+                return
+            }
+
+            worldName = sender.location.world.name
+        }
+
+        // Make sure the group actually has the world in it
+        if (!group.containsWorld(worldName))
+        {
+            sender.sendMessage("${ChatColor.DARK_RED}» ${ChatColor.GRAY}No world in group '$groupName' called '$worldName'!")
+            return
+        }
+
+        group.removeWorld(worldName)
+        groupManager.saveGroups()
+        sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Removed the world '$worldName' from group '$groupName'!")
+    }
+}

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
@@ -49,7 +49,6 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         groupManager.addGroup(name, worlds.toMutableSet(), gameMode)
-        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group created successfully!")
     }
 
@@ -88,7 +87,6 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         group.addWorld(worldName)
-        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Added the world '$worldName' to group '$groupName'!")
     }
 
@@ -104,7 +102,6 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         groupManager.removeGroup(group)
-        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group removed successfully!")
     }
 
@@ -150,7 +147,6 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         group.removeWorld(worldName)
-        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Removed the world '$worldName' from group '$groupName'!")
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemSerializer.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/serialization/ItemSerializer.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 object ItemSerializer
 {
 
-    private val AIR = "AIR"
+    private const val AIR = "AIR"
 
     /**
      * Serialize an ItemStack to a JsonObject.

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/service/BukkitService.kt
@@ -31,6 +31,16 @@ class BukkitService @Inject constructor(private val plugin: PerWorldInventory)
     fun runTaskAsynchronously(task: () -> Unit) =
         scheduler.runTaskAsynchronously(plugin, task)
 
+    /**
+     * Run a task that may or may not be asynchronous depending on the
+     * parameter passed to this function.
+     *
+     * @param task The task to run
+     * @param async If the task should be run asynchronously
+     */
+    fun runTaskOptionallyAsynchronously(task: () -> Unit, async: Boolean) =
+            if (async) { scheduler.runTaskAsynchronously(plugin, task) } else { scheduler.runTask(plugin, task) }
+
     fun runTask(task: () -> Unit): BukkitTask =
         scheduler.runTask(plugin, task)
 

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommandsTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommandsTest.kt
@@ -1,0 +1,201 @@
+package me.ebonjaeger.perworldinventory.command
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.nhaarman.mockito_kotlin.given
+import com.nhaarman.mockito_kotlin.verify
+import me.ebonjaeger.perworldinventory.Group
+import me.ebonjaeger.perworldinventory.GroupManager
+import me.ebonjaeger.perworldinventory.service.BukkitService
+import org.bukkit.Bukkit
+import org.bukkit.GameMode
+import org.bukkit.World
+import org.bukkit.command.CommandSender
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import java.io.File
+import kotlin.test.assertNull
+
+/**
+ * Tests for [GroupCommands].
+ */
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(Bukkit::class, BukkitService::class)
+class GroupCommandsTest
+{
+
+    private val bukkitService = mock(BukkitService::class.java)
+    private val groupManager = GroupManager(File(""), bukkitService)
+    private val commands = GroupCommands(groupManager)
+
+    @Before
+    fun createMocks()
+    {
+        PowerMockito.mockStatic(Bukkit::class.java)
+    }
+
+    @Test
+    fun addGroupButAlreadyExists()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+
+        // when
+        commands.onAddGroup(sender, "test", "survival", "test", "test_nether")
+
+        // then
+        verify(sender).sendMessage("§4» §7A group called 'test' already exists!")
+        assertThat(groupManager.groups.size, equalTo(1))
+    }
+
+    @Test
+    fun addGroupButInvalidGameMode()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+
+        // when
+        commands.onAddGroup(sender, "test", "invalid", "creative")
+
+        // then
+        verify(sender).sendMessage("§4» §7'invalid' is not a valid GameMode!")
+        assertNull(groupManager.getGroup("test"))
+    }
+
+    @Test
+    fun addGroupSuccessfully()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+
+        // when
+        commands.onAddGroup(sender, "test", "creative", "creative")
+
+        // then
+        val expected = Group("test", mutableSetOf("creative"), GameMode.CREATIVE)
+        assertThat(groupManager.getGroup("test"), equalTo(expected))
+    }
+
+    @Test
+    fun addWorldInvalidGroup()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+
+        // when
+        commands.onAddWorld(sender, "bob", "bobs_world")
+
+        // then
+        verify(sender).sendMessage("§4» §7No group with that name exists!")
+    }
+
+    @Test
+    fun addWorldInvalidWorld()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+
+        // when
+        commands.onAddWorld(sender, "test", "invalid")
+
+        // then
+        verify(sender).sendMessage("§4» §7No world with that name exists!")
+    }
+
+    @Test
+    fun addWorldSuccessfully()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        val world = mock(World::class.java)
+        given(Bukkit.getWorld("bob")).willReturn(world)
+        given(world.name).willReturn("bob")
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+
+        // when
+        commands.onAddWorld(sender, "test", "bob")
+
+        // then
+        val expected = Group("test", mutableSetOf("test", "bob"), GameMode.SURVIVAL)
+        assertThat(groupManager.getGroup("test"), equalTo(expected))
+    }
+
+    @Test
+    fun removeGroupInvalidName()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+
+        // when
+        commands.onRemoveGroup(sender, "invalid")
+
+        // then
+        verify(sender).sendMessage("§4» §7No group with that name exists!")
+    }
+
+    @Test
+    fun removeGroupSuccessfully()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        groupManager.addGroup("test", mutableSetOf("bob"), GameMode.ADVENTURE)
+
+        // when
+        commands.onRemoveGroup(sender, "test")
+
+        // then
+        assertNull(groupManager.getGroup("test"))
+    }
+
+    @Test
+    fun removeWorldInvalidGroup()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+
+        // when
+        commands.onRemoveWorld(sender, "bob", "bobs_world")
+
+        // then
+        verify(sender).sendMessage("§4» §7No group with that name exists!")
+    }
+
+    @Test
+    fun removeWorldInvalidWorld()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+
+        // when
+        commands.onRemoveWorld(sender, "test", "invalid")
+
+        // then
+        verify(sender).sendMessage("§4» §7No world with that name exists!")
+    }
+
+    @Test
+    fun removeWorldSuccessfully()
+    {
+        // given
+        val sender = mock(CommandSender::class.java)
+        val world = mock(World::class.java)
+        given(Bukkit.getWorld("bob")).willReturn(world)
+        given(world.name).willReturn("bob")
+        groupManager.addGroup("test", mutableSetOf("test", "bob"), GameMode.SURVIVAL)
+
+        // when
+        commands.onRemoveWorld(sender, "test", "bob")
+
+        // then
+        val expected = Group("test", mutableSetOf("test"), GameMode.SURVIVAL)
+        assertThat(groupManager.getGroup("test"), equalTo(expected))
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to add, remove and modify Groups via commands. With this, plugin users can configure their world groups easier without worrying about the syntax of the configuration file. Hopefully, this will reduce the number of configuration errors based on a broken file format.

---

This adds a few new permissions for commands:
- `perworldinventory.command.groups.list` -> List all current groups
- `perworldinventory.command.groups.add` -> Add a new group
- `perworldinventory.command.groups.remove` -> Remove an existing group
- `perworldinventory.command.groups.modify` -> Modify an existing group (add/remove worlds, etc.)

---

Before this is merged, it would be nice to have unit tests written to make sure these, in theory, work as intended.