### PR TITLE
Go back to YAML for worlds configuration

### DIFF
--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/Group.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/Group.kt
@@ -4,7 +4,7 @@ import org.bukkit.GameMode
 import java.util.*
 
 /**
- * A group of worlds, typically defined in the worlds.json file.
+ * A group of worlds, typically defined in the worlds.yml file.
  * Each Group has a name, and should have a list of worlds in that group, as well as
  * a default GameMode.
  *
@@ -20,7 +20,7 @@ data class Group(val name: String,
 {
 
     /**
-     * If this is true, then this group was configured in the `worlds.json`
+     * If this is true, then this group was configured in the `worlds.yml`
      * file. If the group was created on the fly due to a world not being in
      * a group, then this will be false.
      */

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -1,23 +1,18 @@
 package me.ebonjaeger.perworldinventory
 
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
-import com.google.gson.stream.JsonReader
 import me.ebonjaeger.perworldinventory.initialization.PluginFolder
 import me.ebonjaeger.perworldinventory.service.BukkitService
 import org.bukkit.GameMode
+import org.bukkit.configuration.file.YamlConfiguration
 import java.io.File
-import java.io.FileReader
-import java.io.FileWriter
+import java.io.IOException
 import javax.inject.Inject
 
 class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
                                        private val bukkitService: BukkitService)
 {
 
-    private val WORLDS_CONFIG_FILE = File(pluginFolder, "worlds.json")
+    private val WORLDS_CONFIG_FILE = File(pluginFolder, "worlds.yml")
 
     val groups = mutableMapOf<String, Group>()
 
@@ -27,10 +22,12 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
      * @param name The name of the group
      * @param worlds A Set of world names
      * @param gameMode The default GameMode for this group
+     * @param configured If the group was configured (true) or created on the fly (false)
      */
-    fun addGroup(name: String, worlds: MutableSet<String>, gameMode: GameMode)
+    fun addGroup(name: String, worlds: MutableSet<String>, gameMode: GameMode, configured: Boolean)
     {
         val group = Group(name, worlds, gameMode)
+        group.configured = configured
         ConsoleLogger.debug("Adding group to memory: $group")
         groups[name.toLowerCase()] = group
     }
@@ -56,17 +53,14 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
      */
     fun getGroupFromWorld(world: String): Group
     {
-        groups.values.forEach {
-            if (it.containsWorld(world))
-            {
-                return it
-            }
-        }
+        var group = groups.values.firstOrNull { it.containsWorld(world) }
+        if (group != null) return group
 
         // If we reach this point, the group doesn't yet exist.
         val worlds = mutableSetOf(world, "${world}_nether", "${world}_the_end")
-        val group = Group(world, worlds, GameMode.SURVIVAL)
-        groups[world.toLowerCase()] = group
+        group = Group(world, worlds, GameMode.SURVIVAL)
+
+        addGroup(world, worlds, GameMode.SURVIVAL, false)
         ConsoleLogger.warning("Creating a new group on the fly for '$world'." +
                 " Please double check your `worlds.json` file configuration!")
 
@@ -92,27 +86,13 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
         groups.clear()
 
         bukkitService.runTaskAsynchronously({
-            JsonReader(FileReader(WORLDS_CONFIG_FILE)).use {
-                val parser = JsonParser()
-                val data = parser.parse(it).asJsonObject
-                val root = data["groups"].asJsonObject
-
-                bukkitService.runTask({
-                    root.entrySet().forEach { jsonGroup ->
-                        val jsonObject = root[jsonGroup.key].asJsonObject
-                        val name = jsonGroup.key
-
-                        val worlds = mutableSetOf<String>()
-                        jsonObject["worlds"].asJsonArray.forEach { worlds.add(it.asString) }
-
-                        val defaultGameMode = GameMode.valueOf(jsonObject["default-gamemode"].asString.toUpperCase())
-                        val group = Group(name, worlds, defaultGameMode)
-                        group.configured = true
-
-                        groups[group.name.toLowerCase()] = group
-                        ConsoleLogger.debug("Loaded group into memory: $group")
-                    }
-                })
+            val yaml = YamlConfiguration.loadConfiguration(WORLDS_CONFIG_FILE)
+            bukkitService.runTask {
+                yaml.getConfigurationSection("groups.").getKeys(false).forEach { key ->
+                    val worlds = yaml.getStringList("groups.$key.worlds").toMutableSet()
+                    val gameMode = GameMode.valueOf( (yaml.getString("groups.$key.default-gamemode") ?: "SURVIVAL").toUpperCase() )
+                    addGroup(key, worlds, gameMode, true)
+                }
             }
         })
     }
@@ -122,28 +102,25 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
      */
     fun saveGroups()
     {
-        val gson = GsonBuilder().setPrettyPrinting().create()
-        val root = JsonObject()
-        val groups = JsonObject()
+        val config = YamlConfiguration.loadConfiguration(WORLDS_CONFIG_FILE)
+        config.set("groups", null)
 
-        this.groups.values.forEach {
-            val group = JsonObject()
-            group.addProperty("name", it.name)
+        groups.values.forEach { toYaml(it, config) }
 
-            val worlds = JsonArray()
-            it.worlds.forEach { worlds.add(it) }
-            group.add("worlds", worlds)
-            group.addProperty("default-gamemode", it.defaultGameMode.name)
-
-            groups.add(it.name, group)
+        try
+        {
+            config.save(WORLDS_CONFIG_FILE)
+        } catch (ex: IOException)
+        {
+            ConsoleLogger.warning("Could not save the groups config to disk:", ex)
         }
+    }
 
-        root.add("groups", groups)
-
-        bukkitService.runTaskOptionallyAsynchronously({
-            FileWriter(WORLDS_CONFIG_FILE).use {
-                it.write(gson.toJson(root))
-            }
-        }, !bukkitService.isShuttingDown())
+    private fun toYaml(group: Group, config: YamlConfiguration)
+    {
+        val key = "groups.${group.name}"
+        config.set(key, null)
+        config.set("$key.worlds", group.worlds)
+        config.set("$key.default-gamemode", group.defaultGameMode.toString())
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/GroupManager.kt
@@ -62,7 +62,7 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
 
         addGroup(world, worlds, GameMode.SURVIVAL, false)
         ConsoleLogger.warning("Creating a new group on the fly for '$world'." +
-                " Please double check your `worlds.json` file configuration!")
+                " Please double check your `worlds.yml` file configuration!")
 
         return group
     }
@@ -79,7 +79,7 @@ class GroupManager @Inject constructor(@PluginFolder pluginFolder: File,
     }
 
     /**
-     * Load the groups configured in the file `worlds.json` into memory.
+     * Load the groups configured in the file `worlds.yml` into memory.
      */
     fun loadGroups()
     {

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/api/PerWorldInventoryAPI.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/api/PerWorldInventoryAPI.kt
@@ -19,7 +19,7 @@ class PerWorldInventoryAPI @Inject constructor(private val plugin: PerWorldInven
 
     /**
      * Check if two worlds are a part of the same [Group] and thus can share
-     * inventories. If one of the groups is not configured in the worlds.json,
+     * inventories. If one of the groups is not configured in the worlds.yml,
      * this method will return true if the option for sharing inventories
      * between non-configured worlds is true in the config.yml file.
      *

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommands.kt
@@ -48,7 +48,8 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
             return
         }
 
-        groupManager.addGroup(name, worlds.toMutableSet(), gameMode)
+        groupManager.addGroup(name, worlds.toMutableSet(), gameMode, true)
+        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group created successfully!")
     }
 
@@ -87,6 +88,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         group.addWorld(worldName)
+        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Added the world '$worldName' to group '$groupName'!")
     }
 
@@ -102,6 +104,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         groupManager.removeGroup(group)
+        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Group removed successfully!")
     }
 
@@ -147,6 +150,7 @@ class GroupCommands @Inject constructor(private val groupManager: GroupManager) 
         }
 
         group.removeWorld(worldName)
+        groupManager.saveGroups()
         sender.sendMessage("${ChatColor.GREEN}» ${ChatColor.GRAY}Removed the world '$worldName' from group '$groupName'!")
     }
 }

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertService.kt
@@ -57,7 +57,7 @@ class ConvertService @Inject constructor(private val bukkitService: BukkitServic
 
             if (pwiGroup == null)
             {
-                groupManager.addGroup(it.name, worlds, GameMode.SURVIVAL)
+                groupManager.addGroup(it.name, worlds, GameMode.SURVIVAL, true)
             } else
             {
                 pwiGroup.addWorlds(worlds)
@@ -68,13 +68,15 @@ class ConvertService @Inject constructor(private val bukkitService: BukkitServic
         bukkitService.runRepeatingTaskAsynchronously(task, 0, 1)
     }
 
-    fun disableMVI()
+    fun finish()
     {
         val mvinventory = pluginManager.getPlugin("Multiverse-Inventories")
         if (mvinventory != null && pluginManager.isPluginEnabled(mvinventory))
         {
             pluginManager.disablePlugin(mvinventory)
         }
+
+        groupManager.saveGroups()
     }
 
     fun executeConvert(batch: Collection<OfflinePlayer>)

--- a/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTask.kt
+++ b/src/main/kotlin/me/ebonjaeger/perworldinventory/conversion/ConvertTask.kt
@@ -56,7 +56,7 @@ class ConvertTask (private val convertService: ConvertService,
         sender.sendMessage("${ChatColor.BLUE}» ${ChatColor.GRAY}Conversion has " +
                 "been completed! Disabling MultiVerse-Inventories...")
 
-        convertService.disableMVI()
+        convertService.finish()
 
         sender.sendMessage("${ChatColor.BLUE}» ${ChatColor.GRAY}" +
                 "MultiVerse-Inventories disabled! Don't forget to remove the .jar!")

--- a/src/main/resources/worlds.json
+++ b/src/main/resources/worlds.json
@@ -1,8 +1,0 @@
-{
-  "groups": {
-    "default": {
-      "worlds": ["world", "world_nether", "world_the_end"],
-      "default-gamemode": "SURVIVAL"
-    }
-  }
-}

--- a/src/main/resources/worlds.yml
+++ b/src/main/resources/worlds.yml
@@ -1,0 +1,25 @@
+# In this file you define your groups and the worlds in them.
+# Follow this format:
+# groups:
+#   default:
+#     worlds:
+#     - world
+#     - world_nether
+#     - world_the_end
+#     default-gamemode: SURVIVAL
+#   creative:
+#     worlds:
+#     - creative
+#     default-gamemode: CREATIVE
+#
+# 'default' and 'creative' are the names of the groups
+# worlds: is a list of all worlds in the group
+# If you have 'manage-gamemodes' set to true in the main config, the server
+# will use the 'default-gamemode' here to know what gamemode to put users in.
+groups:
+  default:
+    worlds:
+    - world
+    - world_nether
+    - world_the_end
+    default-gamemode: SURVIVAL

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/GroupManagerTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/GroupManagerTest.kt
@@ -40,7 +40,7 @@ class GroupManagerTest {
         val gameMode = GameMode.SURVIVAL
 
         // when
-        groupManager.addGroup(name, worlds, gameMode)
+        groupManager.addGroup(name, worlds, gameMode, true)
 
         // then
         val expected = mockGroup(name, worlds, gameMode)
@@ -59,7 +59,7 @@ class GroupManagerTest {
         val gameMode = GameMode.SURVIVAL
 
         // when
-        groupManager.addGroup(name, worlds, gameMode)
+        groupManager.addGroup(name, worlds, gameMode, true)
 
         // then
         val expected = mockGroup(name, worlds, gameMode)
@@ -78,7 +78,7 @@ class GroupManagerTest {
         val gameMode = GameMode.SURVIVAL
 
         // when
-        groupManager.addGroup(name, worlds, gameMode)
+        groupManager.addGroup(name, worlds, gameMode, true)
 
         // then
         val expected = mockGroup(name, worlds, gameMode)
@@ -95,7 +95,7 @@ class GroupManagerTest {
         val name = "test"
         val worlds = mutableSetOf(name)
         val gameMode = GameMode.SURVIVAL
-        groupManager.addGroup(name, worlds, gameMode)
+        groupManager.addGroup(name, worlds, gameMode, true)
 
         // when
         val result = groupManager.getGroupFromWorld(name)

--- a/src/test/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommandsTest.kt
+++ b/src/test/kotlin/me/ebonjaeger/perworldinventory/command/GroupCommandsTest.kt
@@ -36,7 +36,7 @@ class GroupCommandsTest
     @Before
     fun createMocks()
     {
-        PowerMockito.mockStatic(Bukkit::class.java)
+        PowerMockito.mockStatic(Bukkit::class.java, BukkitService::class.java)
     }
 
     @Test
@@ -44,7 +44,7 @@ class GroupCommandsTest
     {
         // given
         val sender = mock(CommandSender::class.java)
-        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL, true)
 
         // when
         commands.onAddGroup(sender, "test", "survival", "test", "test_nether")
@@ -100,7 +100,7 @@ class GroupCommandsTest
     {
         // given
         val sender = mock(CommandSender::class.java)
-        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL, true)
 
         // when
         commands.onAddWorld(sender, "test", "invalid")
@@ -117,7 +117,7 @@ class GroupCommandsTest
         val world = mock(World::class.java)
         given(Bukkit.getWorld("bob")).willReturn(world)
         given(world.name).willReturn("bob")
-        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL, true)
 
         // when
         commands.onAddWorld(sender, "test", "bob")
@@ -145,7 +145,7 @@ class GroupCommandsTest
     {
         // given
         val sender = mock(CommandSender::class.java)
-        groupManager.addGroup("test", mutableSetOf("bob"), GameMode.ADVENTURE)
+        groupManager.addGroup("test", mutableSetOf("bob"), GameMode.ADVENTURE, true)
 
         // when
         commands.onRemoveGroup(sender, "test")
@@ -172,7 +172,7 @@ class GroupCommandsTest
     {
         // given
         val sender = mock(CommandSender::class.java)
-        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL)
+        groupManager.addGroup("test", mutableSetOf("test"), GameMode.SURVIVAL, true)
 
         // when
         commands.onRemoveWorld(sender, "test", "invalid")
@@ -189,7 +189,7 @@ class GroupCommandsTest
         val world = mock(World::class.java)
         given(Bukkit.getWorld("bob")).willReturn(world)
         given(world.name).willReturn("bob")
-        groupManager.addGroup("test", mutableSetOf("test", "bob"), GameMode.SURVIVAL)
+        groupManager.addGroup("test", mutableSetOf("test", "bob"), GameMode.SURVIVAL, true)
 
         // when
         commands.onRemoveWorld(sender, "test", "bob")


### PR DESCRIPTION
After a lot of thought and some user feedback, I feel it would be better to keep the existing YAML structure for the worlds configuration files. Now that server administrators have the ability to modify their group setups using commands, it should be fine to stick with YAML and still have less configuration issues.


Given that this is still in Beta with plenty of warnings, no automatic conversion from Json back to Yaml will be included.
